### PR TITLE
Remove java dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ Dependencies.toml
 
 #Ignore all .deb files
 *.deb
+
+.idea
+
+**/bin/**

--- a/edi-tools-cli/.gitignore
+++ b/edi-tools-cli/.gitignore
@@ -3,3 +3,5 @@
 
 # Ignore Gradle build output directory
 build
+
+src/main/resources/edi-tool

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
@@ -33,7 +33,6 @@ import java.nio.file.StandardCopyOption;
 
 @CommandLine.Command(name = "codegen", description = "Generates Ballerina records and parser functions for a given EDI schema.")
 public class CodegenCmd implements BLauncherCmd {
-    private static final String EDI_TOOL = "editools.jar";
     private static final String CMD_NAME = "codegen";
 
     private final PrintStream printStream;
@@ -58,14 +57,11 @@ public class CodegenCmd implements BLauncherCmd {
         }
         try {
             printStream.println("Generating code for " + schemaPath + "...");
-            Class<?> clazz = CodegenCmd.class;
-            ClassLoader classLoader = clazz.getClassLoader();
-            Path tempFile = Files.createTempFile(null, null);
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
+            Path tempFolder = Files.createTempDirectory(null);
+            Util.copyFromJar(tempFolder);
             ProcessBuilder processBuilder = new ProcessBuilder(
-                    "java", "-jar", tempFile.toAbsolutePath().toString(), "codegen", schemaPath, outputPath);
+                    "bal", "run",  tempFolder.toAbsolutePath().toString(), "--", "codegen",
+                    schemaPath, outputPath);
             processBuilder.inheritIO();
             Process process = processBuilder.start();
             process.waitFor();

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/Util.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/Util.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.edi.cmd;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+
+public class Util {
+    private static final String EDI_TOOL_BAL_FOLDER = "edi-tool";
+
+    public static void copyFromJar(final Path target) throws IOException, URISyntaxException {
+        Class<?> clazz = Util.class;
+        ClassLoader classLoader = clazz.getClassLoader();
+        URI resource = classLoader.getResource(EDI_TOOL_BAL_FOLDER).toURI();
+        FileSystem fileSystem = FileSystems.newFileSystem(
+                resource,
+                Collections.<String, String>emptyMap()
+        );
+
+
+        final Path jarPath = fileSystem.getPath(EDI_TOOL_BAL_FOLDER);
+        Files.walkFileTree(jarPath, new SimpleFileVisitor<>() {
+
+            private Path currentTarget;
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                currentTarget = target.resolve(jarPath.relativize(dir).toString());
+                Files.createDirectories(currentTarget);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.copy(file, target.resolve(jarPath.relativize(file).toString()), StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+
+        });
+    }
+}

--- a/edi-tools/.devcontainer.json
+++ b/edi-tools/.devcontainer.json
@@ -1,4 +1,0 @@
-{
-    "image": "ballerina/ballerina-devcontainer:2201.4.1",
-    "extensions": ["WSO2.ballerina"],
-}

--- a/edi-tools/build.gradle
+++ b/edi-tools/build.gradle
@@ -59,11 +59,13 @@ task copyEdiToolsJar {
     // Copy edi-tools jar to resources folder
     doLast {
         copy {
-            from "target/bin/editools.jar"
-            into "../edi-tools-cli/src/main/resources"
-            include "*.jar"
+            from "$project.projectDir"
+            into "../edi-tools-cli/src/main/resources/edi-tool"
+            exclude "build.gradle"
+            exclude "**/target/**"
+            exclude "**/bin/**"
         }
-        println "Copying edi-tools jar to resources folder"
+        println "Copying edi-tools bal module to resources folder"
     }
 }
 task test{


### PR DESCRIPTION
## Purpose
As a workaround I have packed the entire ballerina tools package inside the edi-tools.jar. 

The ballerina package is run dueing tool invocation rather than java.

Note: USer still needs to have ballerina installed in the machine