### PR TITLE
Fix for Invalid Package Name Error During Package Generation

### DIFF
--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
@@ -59,7 +59,7 @@ public class LibgenCmd implements BLauncherCmd {
             printStream.println(stringBuilder.toString());
             return;
         }
-        if (!packageName.matches("^[a-z0-9]+/[a-z0-9]+$")) {
+        if (!packageName.matches("^[a-zA-Z0-9_]+/[a-zA-Z0-9_]+$")) {
             printStream.println("Invalid package name. Package name should be in the format orgname/packagename");
             return;
         }

--- a/edi-tools-package/BalTool.toml
+++ b/edi-tools-package/BalTool.toml
@@ -2,4 +2,4 @@
 id = "edi"
 
 [[dependency]]
-path = "resources/edi-tools-cli-2.0.1.jar"
+path = "resources/edi-tools-cli-2.0.2.jar"

--- a/edi-tools-package/Ballerina.toml
+++ b/edi-tools-package/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "editoolspackage"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]

--- a/edi-tools/Ballerina.toml
+++ b/edi-tools/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "editools"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6804

**Issue Addressed:**
This PR addresses the issue related to invalid package names during the package generation process when uppercase letters are present in the organization name. The error message encountered was:
```
Invalid package name. Package name should be in the format orgname/libname
```

**Problem Description:**
The package generation command fails if the organization name contains uppercase letters. For example, the following command results in an error:
```
bal edi libgen -p MyOrg/porder -i MyOrg/schemas -o MyOrg/lib
```
However, the command works as expected when the organization name is in lowercase:
```
bal edi libgen -p myorg/porder -i MyOrg/schemas -o myorg/lib
```

**Solution:**
This PR modifies the package validation logic to allow uppercase letters in the organization name, ensuring that the package generation process can handle organization names with uppercase letters without resulting in an error.