### PR TITLE
Fix JSON to EDI Data Binding in REST client

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Usually, organizations have to work with many EDI formats, and integration devel
 The below command can be used to generate Ballerina records, parser and util functions, and a REST connector for a given collection of EDI schemas organized into a Ballerina package:
 
 ```
-bal edi libgen -p <package name> -i <input schema folder> -o <output folder>
+bal edi libgen -p <organization-name/package-name> -i <input schema folder> -o <output folder>
 ```
 
 The Ballerina package will be generated in the output folder. This package can be built and published by issuing "bal pack" and "bal push" commands from the output folder. Then the generated package can be imported into any Ballerina project and generated utility functions of the package can be invoked to parse EDI messages into Ballerina records. 

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
@@ -59,8 +59,11 @@ public class LibgenCmd implements BLauncherCmd {
             printStream.println(stringBuilder.toString());
             return;
         }
-        if (!packageName.matches("^[a-zA-Z0-9_]+/[a-zA-Z0-9_.]+$")) {
-            printStream.println("Invalid package name. Package name should be in the format orgname/packagename");
+        if (!packageName.matches("^[a-zA-Z0-9_]{1,256}/[a-zA-Z0-9_.]{1,256}$")) {
+            printStream.println(
+                    "Invalid package name. Package name should be in the format orgname/packagename."+
+                    " The orgname part must contain only alphanumeric characters or underscores and be 1 to 256 characters long."+
+                    " The packagename part must contain only alphanumeric characters, underscores, or periods and be 1 to 256 characters long.");
             return;
         }
         try {

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
@@ -59,7 +59,7 @@ public class LibgenCmd implements BLauncherCmd {
             printStream.println(stringBuilder.toString());
             return;
         }
-        if (!packageName.matches("^[a-zA-Z0-9_]+/[a-zA-Z0-9_]+$")) {
+        if (!packageName.matches("^[a-zA-Z0-9_]+/[a-zA-Z0-9_.]+$")) {
             printStream.println("Invalid package name. Package name should be in the format orgname/packagename");
             return;
         }

--- a/edi-tools-package/BalTool.toml
+++ b/edi-tools-package/BalTool.toml
@@ -2,4 +2,4 @@
 id = "edi"
 
 [[dependency]]
-path = "resources/edi-tools-cli-2.0.2.jar"
+path = "resources/edi-tools-cli-2.0.3.jar"

--- a/edi-tools-package/Ballerina.toml
+++ b/edi-tools-package/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "editoolspackage"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]

--- a/edi-tools/Ballerina.toml
+++ b/edi-tools/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "editools"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]

--- a/edi-tools/modules/codegen/transformer_gen.bal
+++ b/edi-tools/modules/codegen/transformer_gen.bal
@@ -34,7 +34,7 @@ isolated function transformRead(${mainRecordName} data) returns InternalType => 
 # + content - Ballerina record to be converted
 # + return - EDI string or error
 public isolated function transformToEdiString(anydata content) returns string|error {
-    ${mainRecordName} data = transformWrite(check content.ensureType());
+    ${mainRecordName} data = transformWrite(check content.cloneWithType());
     return toEdiString(data);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6813

This pull request introduces several enhancements and fixes to the EDI REST codegen functionality. Below are the key changes included in this PR:

1. **Limit Package Name Length**: The organization and package name length has been limited to a maximum of 256 characters. This change helps ensure that our package naming conventions adhere to commonly accepted standards and prevents issues related to overly long names that could affect system performance and usability.

2. **Fix JSON to EDI Code Generation**: Addressed an issue in the JSON to EDI REST code generation process. This fix ensures that the conversion logic correctly handles all specified edge cases, improving the reliability of our code generation tool.

3. **Add Examples for REST Codegen**: Added new examples to the REST code generation documentation. These examples are intended to provide clearer guidance and support for users utilizing our codegen tools, demonstrating practical use cases and enhancing user understanding.
