### PR TITLE
Add headerSegments/trailerSegments to EDIFACT and X12 schema generation

### DIFF
--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -6,3 +6,9 @@ authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]
 distribution = "2201.11.0"
+
+[[dependency]]
+org = "ballerina"
+name = "edi"
+version = "@stdlib.edi.native.version@"
+repository = "local"

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,11 @@ subprojects {
         ballerinaStdLibs "io.ballerina.stdlib:time-ballerina:${project.stdlibTimeVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${project.observeVersion}"
         ballerinaStdLibs "io.ballerina:observe-ballerina:${project.observeInternalVersion}"
+
+        /* edi module — consumed as a snapshot bala from GitHub Packages because the
+         * tool depends on APIs that are not yet on Central. Unpacked into the local
+         * Ballerina repo by `unpackEdiBala` in `edi-tools/build.gradle`. */
+        ballerinaStdLibs "io.ballerina.stdlib:edi-ballerina:${project.stdlibEdiVersion}@zip"
     }
 }
 

--- a/edi-tools/Ballerina.toml
+++ b/edi-tools/Ballerina.toml
@@ -6,3 +6,9 @@ authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]
 distribution = "2201.11.0"
+
+[[dependency]]
+org = "ballerina"
+name = "edi"
+version = "1.6.0"
+repository = "local"

--- a/edi-tools/build.gradle
+++ b/edi-tools/build.gradle
@@ -30,7 +30,21 @@ task updateTomlFiles {
         println "Updating toml files"
         def newConfig = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
+        newConfig = newConfig.replace("@stdlib.edi.native.version@",
+                stripBallerinaExtensionVersion(project.stdlibEdiVersion))
         ballerinaTomlFile.text = newConfig
+    }
+}
+
+// Unpack the edi-ballerina snapshot bala from GitHub Packages into
+// ~/.ballerina/repositories/local so `bal build` resolves the dependency declared
+// in edi-tools/Ballerina.toml ([[dependency]] ... repository = "local"). Mirrors
+// the io.ballerina.plugin `copyStdlibs` behaviour used by stdlib repos like sql.
+task unpackEdiBala(type: Copy) {
+    def edibala = configurations.ballerinaStdLibs.find { it.name.startsWith("edi-ballerina-") && it.name.endsWith(".zip") }
+    if (edibala != null) {
+        from zipTree(edibala)
+        into "${System.getProperty('user.home')}/.ballerina/repositories/local"
     }
 }
 
@@ -96,5 +110,6 @@ task build {
 
 buildEDIToolCore.dependsOn deleteTarget
 buildEDIToolCore.dependsOn updateTomlFiles
+buildEDIToolCore.dependsOn unpackEdiBala
 copyEdiToolsJar.dependsOn buildEDIToolCore
 test.dependsOn buildEDIToolCore

--- a/edi-tools/modules/codegen/libgen.bal
+++ b/edi-tools/modules/codegen/libgen.bal
@@ -49,6 +49,12 @@ public function generateLibrary(LibData libdata) returns error? {
         check generateCodeFromSchemas(libdata, "", ());
     }
     check createBalLib(libdata);
+    io:println(string `
+NOTE: The generated library uses the headerSegments and trailerSegments fields
+in its embedded schema JSON. These fields were introduced in ballerina/edi 1.6.0,
+so the library must be built and run against ballerina/edi >= 1.6.0. Older
+versions will fail to deserialize the schema with a "field cannot be added to
+the closed record 'edi:EdiSchema'" error.`);
 }
 
 function createLibStructure(LibData libdata) returns error? {

--- a/edi-tools/modules/codegen/schema_code_gen.bal
+++ b/edi-tools/modules/codegen/schema_code_gen.bal
@@ -25,11 +25,42 @@ public function generateCodeForSchema(json schema, string outputPath) returns er
         recordsString += rec.toString() + "\n";
     }
 
+    // Generate envelope API functions if the schema includes headerSegments / trailerSegments
+    string headersFunc = "";
+    string envelopeFunc = "";
+    if ediSchema.headerSegments.length() > 0 {
+        headersFunc = string `
+# Parse only the envelope header segments of the EDI text and return immediately.
+# Requires the schema to have headerSegments defined (generated schemas include these).
+#
+# + ediText - EDI string to be parsed
+# + return - Parsed header segments as JSON, or error
+public isolated function headersFromEdiString(string ediText) returns json|error {
+    edi:EdiSchema schema = check edi:getSchema(schemaJson);
+    return edi:headersFromEdiString(ediText, schema);
+}
+`;
+    }
+    if ediSchema.headerSegments.length() > 0 && ediSchema.trailerSegments.length() > 0 {
+        envelopeFunc = string `
+# Parse the EDI text in one pass, returning parsed envelope headers and trailers
+# with the transaction body left as raw segment strings.
+# Requires the schema to have both headerSegments and trailerSegments defined.
+#
+# + ediText - EDI string to be parsed
+# + return - EdiEnvelope with parsed headers, raw body strings, and parsed trailers; or error
+public isolated function envelopeFromEdiString(string ediText) returns edi:EdiEnvelope|error {
+    edi:EdiSchema schema = check edi:getSchema(schemaJson);
+    return edi:envelopeFromEdiString(ediText, schema);
+}
+`;
+    }
+
     string schemaCode = string `
 import ballerina/edi;
 
 # Convert EDI string to Ballerina ${ediSchema.name} record.
-# 
+#
 # + ediText - EDI string to be converted
 # + return - Ballerina record or error
 public isolated function fromEdiString(string ediText) returns ${ediSchema.name}|error {
@@ -39,23 +70,23 @@ public isolated function fromEdiString(string ediText) returns ${ediSchema.name}
 }
 
 # Convert Ballerina ${ediSchema.name} record to EDI string.
-# 
+#
 # + data - Ballerina record to be converted
 # + return - EDI string or error
 public isolated function toEdiString(${ediSchema.name} data) returns string|error {
     edi:EdiSchema ediSchema = check edi:getSchema(schemaJson);
-    return edi:toEdiString(data, ediSchema);    
-} 
+    return edi:toEdiString(data, ediSchema);
+}
 
 # Get the EDI schema.
-# 
+#
 # + return - EDI schema or error
 public isolated function getSchema() returns edi:EdiSchema|error {
     return edi:getSchema(schemaJson);
 }
 
 # Convert EDI string to Ballerina ${ediSchema.name} record with schema.
-# 
+#
 # + ediText - EDI string to be converted
 # + schema - EDI schema
 # + return - Ballerina record or error
@@ -65,14 +96,16 @@ public isolated function fromEdiStringWithSchema(string ediText, edi:EdiSchema s
 }
 
 # Convert Ballerina ${ediSchema.name} record to EDI string with schema.
-# 
+#
 # + data - Ballerina record to be converted
 # + ediSchema - EDI schema
 # + return - EDI string or error
 public isolated function toEdiStringWithSchema(${ediSchema.name} data, edi:EdiSchema ediSchema) returns string|error {
-    return edi:toEdiString(data, ediSchema);    
+    return edi:toEdiString(data, ediSchema);
 }
 
+${headersFunc}
+${envelopeFunc}
 ${recordsString}
 
 final readonly & json schemaJson = ${schema.toJsonString()};

--- a/edi-tools/modules/edifact/edifact.bal
+++ b/edi-tools/modules/edifact/edifact.bal
@@ -51,7 +51,9 @@ type EDISchema record {|
     string name;
     string[] ignoreSegments;
     Delimiters delimiters;
+    (Segement|SegmentGroup)[] headerSegments = [];
     (Segement|SegmentGroup)[] segments;
+    (Segement|SegmentGroup)[] trailerSegments = [];
     SegmentDefintions segmentDefinitions;
 |};
 
@@ -117,7 +119,7 @@ function genEdiSchema(string url, string code, string dir, SegmentDefintions all
 function genMsgTypeEdiSchema(string msgType, SegmentDefintions segmentDefinitions, string name) returns EDISchema|error {
     EDISchema ediSchema = {
         name,
-        ignoreSegments: ["UNB"],
+        ignoreSegments: ["UNB", "UNA"],
         delimiters: {
             segment: "'",
             'field: "+",
@@ -146,7 +148,25 @@ function genMsgTypeEdiSchema(string msgType, SegmentDefintions segmentDefinition
     regexp:Groups[] segments = segmentGroupOrSegmentReg.findAllGroups(segmentTable);
 
     check genSegmentsSchema(segments, segmentDefinitions, ediSchema.segments, ediSchema.segmentDefinitions);
+    extractEdifactEnvelopeSegments(ediSchema);
     return ediSchema;
+}
+
+# Extracts UNH (message header) and UNT (message trailer) segments from the flat
+# segments array into headerSegments and trailerSegments respectively.
+# This enables the tiered envelope parsing API in ballerina/edi.
+function extractEdifactEnvelopeSegments(EDISchema ediSchema) {
+    (Segement|SegmentGroup)[] remaining = [];
+    foreach Segement|SegmentGroup seg in ediSchema.segments {
+        if seg is Segement && seg.ref == "UNH" {
+            ediSchema.headerSegments.push(seg);
+        } else if seg is Segement && seg.ref == "UNT" {
+            ediSchema.trailerSegments.push(seg);
+        } else {
+            remaining.push(seg);
+        }
+    }
+    ediSchema.segments = remaining;
 }
 
 function genSegmentsSchema(regexp:Groups[] segmentsMatch, map<SegmentDef> allSegmentDefinitions, (Segement|SegmentGroup)[] segments, SegmentDefintions segmentDefintions) returns error? {

--- a/edi-tools/modules/x12xsd/x12xsd.bal
+++ b/edi-tools/modules/x12xsd/x12xsd.bal
@@ -79,6 +79,7 @@ public function convertFromX12Xsd(xml x12xsd) returns edi:EdiSchema|error {
     }
     edi:EdiSegGroupSchema rootSegGroupSchema = check convertSegmentGroup(root, x12xsd, ediSchema);
     ediSchema.segments = rootSegGroupSchema.segments;
+    extractEnvelopeSegments(ediSchema);
     return ediSchema;
 }
 
@@ -100,7 +101,25 @@ function convertFromX12WithHeaders(string inPath) returns edi:EdiSchema|error {
     }
     edi:EdiSegGroupSchema rootSegGroupSchema = check convertSegmentGroup(root, interchangeXsd, ediSchema, inPath);
     ediSchema.segments = rootSegGroupSchema.segments;
+    extractEnvelopeSegments(ediSchema);
     return ediSchema;
+}
+
+# Extracts ST (transaction set header) and SE (transaction set trailer) segments
+# from the flat segments array into headerSegments and trailerSegments respectively.
+# This enables the tiered envelope parsing API in ballerina/edi.
+function extractEnvelopeSegments(edi:EdiSchema ediSchema) {
+    edi:EdiUnitSchema[] remaining = [];
+    foreach edi:EdiUnitSchema seg in ediSchema.segments {
+        if seg is edi:EdiSegSchema && seg.code == "ST" {
+            ediSchema.headerSegments.push(seg);
+        } else if seg is edi:EdiSegSchema && seg.code == "SE" {
+            ediSchema.trailerSegments.push(seg);
+        } else {
+            remaining.push(seg);
+        }
+    }
+    ediSchema.segments = remaining;
 }
 
 function convertSegmentGroup(xml segmentGroup, xml x12xsd, edi:EdiSchema schema, string dirPath = "", int parentMinOccur = 0, int parentMaxOccur = 1) returns edi:EdiSegGroupSchema|error {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,8 @@ stdlibTimeVersion=2.7.0
 # Ballerinax Observer
 observeVersion=1.4.0
 observeInternalVersion=1.4.0
+
+# Stdlib EDI module — pulled as a snapshot bala from GitHub Packages and pushed
+# into ~/.ballerina/repositories/local at build time (see edi-tools/build.gradle).
+# The generated tool's Ballerina.toml references this version via repository="local".
+stdlibEdiVersion=1.6.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Extract envelope segments (UNH/UNT for EDIFACT, ST/SE for X12) into `headerSegments` and `trailerSegments` fields during schema generation
- Generate envelope API functions (`headersFromEdiString`, `envelopeFromEdiString`) in codegen when these fields are present
- Add `UNA` to EDIFACT ignore segments list

## Related Issue
Solves part of https://github.com/ballerina-platform/ballerina-library/issues/8673

## Test plan
- [ ] Verify EDIFACT schema generation correctly extracts UNH/UNT into header/trailer segments
- [ ] Verify X12 schema generation correctly extracts ST/SE into header/trailer segments
- [ ] Verify generated code includes `headersFromEdiString` and `envelopeFromEdiString` functions when envelope segments are present
- [ ] Verify existing `fromEdiString`/`toEdiString` functions continue to work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request extends the EDI schema generation for both EDIFACT and X12 formats to explicitly separate envelope segments (headers and trailers) from message body segments, and generates corresponding API functions for accessing these envelope structures.

## Changes

### Schema Definition Updates
- Added `headerSegments` and `trailerSegments` fields to the `EDISchema` type to store envelope segments separately from message body segments in both EDIFACT and X12 schemas.

### EDIFACT Module
- Envelope segment extraction now automatically identifies UNH (header) and UNT (trailer) segments during schema generation and moves them into the dedicated `headerSegments` and `trailerSegments` collections.
- Updated the ignore segments list to include UNA alongside UNB for proper handling during schema construction.
- Introduced an internal helper function to perform the envelope extraction logic consistently.

### X12 Module
- Similar envelope extraction mechanism that identifies ST (header) and SE (trailer) segments and segregates them into their respective collections within the schema.

### Code Generation
- When envelope segments are present in a schema, the code generator now emits two new public functions:
  - `headersFromEdiString()`: Parses and returns header segments from EDI text when header segments are defined.
  - `envelopeFromEdiString()`: Parses and returns both header and trailer segments as a complete envelope structure when both are defined.
- These generated functions leverage existing schema-level processing methods to delegate the actual parsing logic.

## Impact

This change improves schema clarity by explicitly modeling envelope structures, making them programmatically accessible through dedicated functions. Existing `fromEdiString` and `toEdiString` functionality remains unchanged and continues to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->