### PR TITLE
Add package landing README for the EDI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ For the full schema grammar — delimiters, segment groups, fields, components, 
 
 ### ESL schemas
 
-ESL (Electronic Shelf Labeling) schemas, used for retail pricing feeds, can be converted with `convertESL`, supplying the base segment definitions:
+ESL (EDI Schema Language) is a schema-definition format that describes an EDI message's structure in YAML, alongside a base segment-definitions file. Convert an ESL schema into a Ballerina EDI schema with `convertESL`:
 
 ```
 $ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Electronic Data Interchange (EDI) is how businesses exchange documents such as p
 - **EDIFACT** — the international UN standard, with message types such as `ORDERS`, `INVOIC`, and `DESADV`.
 - **X12** — the ANSI ASC X12 standard used across North America, with transaction sets such as `850` (purchase order), `810` (invoice), and `856` (ship notice).
 
-You do not need to learn the raw EDI wire format. Point the `bal edi` tool at the standard you already work with, and it generates the Ballerina record types and parser functions for you — so a purchase order or invoice becomes an ordinary typed record you read and write like any other Ballerina value.
+The `bal edi` tool generates Ballerina record types and parser functions from an EDI standard's specification, so EDI documents can be processed as typed Ballerina records rather than parsed by hand.
 
 The tool can:
 
-- **Generate code from an EDIFACT or X12 spec** — the common case, covered first below.
+- **Generate code from an EDIFACT or X12 spec** — the most common case.
 - **Bundle several schemas into a reusable library package**, optionally exposed as a REST service.
 - **Generate code from a custom schema** — for proprietary or non-standard formats.
 
@@ -31,7 +31,7 @@ $ bal tool pull edi
 
 ## Generate from an EDIFACT spec
 
-EDIFACT is the international EDI standard. The tool already knows the EDIFACT message specifications, so there is no schema to write — you just name the version and message type.
+EDIFACT is the international EDI standard. The tool includes the EDIFACT message specifications, so the schema is generated from the version and message type — no schema needs to be written by hand.
 
 **Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
 
@@ -47,11 +47,11 @@ $ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 
 `modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
-> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) — you can import those directly without generating anything. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
+> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) and can be imported directly without generating any code. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
 ## Generate from an X12 schema
 
-X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so you start from the X12 schema (XSD) you are entitled to use and convert it.
+X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so the workflow starts from a licensed X12 schema (XSD) and converts it into a Ballerina EDI schema.
 
 **Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
 
@@ -65,7 +65,7 @@ $ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 $ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
 ```
 
-The result is the same shape as the EDIFACT flow: typed records and parser functions you can use right away.
+The result matches the EDIFACT flow: typed records and parser functions ready for use.
 
 ## Using the generated code
 
@@ -112,7 +112,7 @@ public function main() returns error? {
 
 ### Reading and writing EDI envelopes
 
-A real EDI file is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
+An EDI interchange is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
 
 - `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a malformed transaction body is captured rather than aborting the whole parse (fail-safe).
 - `headersFromEdiString` — extracts just the envelope headers (useful for routing).
@@ -175,11 +175,11 @@ public function main() returns error? {
 }
 ```
 
-Because trading partners often use variations of a standard format, you can also generate a partner-specific package from partner-specific schemas.
+Because trading partners often use variations of a standard format, a partner-specific package can be generated from partner-specific schemas.
 
 ### Running a generated package as a REST service
 
-A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — handy when EDI processing should be its own microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
+A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — useful when EDI processing is deployed as a separate microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
 
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
@@ -195,7 +195,7 @@ The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
 
 ## Custom EDI schemas
 
-If you work with a proprietary or non-standard format that is neither X12 nor EDIFACT, describe its structure directly in the Ballerina EDI schema format (JSON) and run `codegen` on it — no conversion step needed. A minimal schema for a simple order looks like:
+For a proprietary or non-standard format that is neither X12 nor EDIFACT, the structure can be described directly in the Ballerina EDI schema format (JSON) and passed to `codegen` without a conversion step. A minimal schema for a simple order looks like:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -180,11 +180,14 @@ A generated package also includes a REST connector, so it can be built (`bal bui
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
 --header 'Content-Type: text/plain' \
---data-raw 'ST*850*0001~
+--data-raw 'GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
+ST*850*0001~
 BEG*00*NE*4500012345**20240802~
 PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*5*0001~'
+SE*5*0001~
+GE*1*1~
+IEA*1*000000001~'
 ```
 
 The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).

--- a/README.md
+++ b/README.md
@@ -1,191 +1,130 @@
 # Ballerina EDI Tools
- 
+
 [![Build](https://github.com/ballerina-platform/edi-tools/actions/workflows/build-timestamped-master.yml/badge.svg)](https://github.com/ballerina-platform/edi-tools/actions/workflows/build-timestamped-master.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/edi-tools.svg)](https://github.com/ballerina-platform/edi-tools/commits/master)
 [![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/edi-tools.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module/edi-tools)
 
 ## Overview
 
-Electronic Data Interchange (EDI) is a technology designed to facilitate the electronic transfer of business documents among various organizations. The Ballerina EDI tool provides a set of command line tools to work with EDI files in Ballerina.
+Electronic Data Interchange (EDI) is how businesses exchange documents such as purchase orders, invoices, and shipping notices with their trading partners. Most EDI traffic follows one of two standards:
+
+- **EDIFACT** — the international UN standard, with message types such as `ORDERS`, `INVOIC`, and `DESADV`.
+- **X12** — the ANSI ASC X12 standard used across North America, with transaction sets such as `850` (purchase order), `810` (invoice), and `856` (ship notice).
+
+You do not need to learn the raw EDI wire format. Point the `bal edi` tool at the standard you already work with, and it generates the Ballerina record types and parser functions for you — so a purchase order or invoice becomes an ordinary typed record you read and write like any other Ballerina value.
+
+The tool can:
+
+- **Generate code from an EDIFACT or X12 spec** — the common case, covered first below.
+- **Bundle several schemas into a reusable library package**, optionally exposed as a REST service.
+- **Generate code from a custom schema** — for proprietary or non-standard formats.
+
+The generated code uses the [`ballerina/edi`](https://github.com/ballerina-platform/module-ballerina-edi) module at runtime.
 
 ## Installation
 
-Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/ballerina/edi/latest).
+Pull the EDI tool from [Ballerina Central](https://central.ballerina.io/):
 
 ```
 $ bal tool pull edi
 ```
 
-## Usage
+## Generate from an EDIFACT spec
 
-The tool supports three main usages as follows.
+EDIFACT is the international EDI standard. The tool already knows the EDIFACT message specifications, so there is no schema to write — you just name the version and message type.
 
-- **Code generation**: Generate Ballerina records and parser functions for a given EDI schema.
-- **Package generation**: Generates Ballerina records, parser functions, utility methods, and a REST connector for a given collection of EDI schemas and organizes those as a Ballerina package.
-- **Schema conversion**: Convert various EDI schema formats to Ballerina EDI schema format.
-
-## Define EDI schema
-
-Prior to utilizing the EDI Tools, it is crucial to define the structure of the EDI data meant for import. Developers have the option to utilize the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for guidance. This specification outlines the essential components required to describe an EDI schema, encompassing attributes such as name, delimiters, segments, field definitions, components, sub-components, and additional configuration options.
-
-As an illustrative example, consider the following EDI schema definition for a _simple order_, assumed to be stored as `schema.json`:
-
-```json
-{
-    "name": "SimpleOrder",
-    "delimiters" : {"segment" : "~", "field" : "*", "component": ":", "repetition": "^"},
-    "segments" : [
-        {
-            "code": "HDR",
-            "tag" : "header",
-            "minOccurances": 1,
-            "fields" : [{"tag": "code"}, {"tag" : "orderId"}, {"tag" : "organization"}, {"tag" : "date"}]
-        },
-        {
-            "code": "ITM",
-            "tag" : "items",
-            "maxOccurances" : -1,
-            "fields" : [{"tag": "code"}, {"tag" : "item"}, {"tag" : "quantity", "dataType" : "int"}]
-        }
-    ]
-}
-```
-
-This schema can be employed to parse EDI documents featuring one HDR segment, mapped to the _header_, and any number of ITM segments, mapped to _items_. The HDR segment incorporates three _fields_, corresponding to _orderId_, _organization_, and _date_. Each ITM segment comprises two fields, mapped to _item_ and _quantity_.
-
-Below is an example of an EDI document that can be parsed using the aforementioned schema. Let's assume that the following EDI information is saved in a file named `sample.edi`:
+**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
 
 ```
-HDR*ORDER_1201*ABC_Store*2008-01-01~
-ITM*A-250*12~
-ITM*A-45*100~
-ITM*D-10*58~
-ITM*K-80*250~
-ITM*T-46*28~
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 ```
 
-## Code generation
-
-The below command can be used to generate typed Ballerina records and parser functions for a given EDI schema.
+**Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-bal edi codegen -i <input schema path> -o <output path>
+$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 ```
 
-The above command generates all Ballerina records and parser functions required for working with data in the given EDI schema and writes those into the file specified in the `output path`. The generated parser function (i.e. `fromEdiString(...)`) can read EDI text files into generated records, which can be accessed from Ballerina code similar to accessing any other Ballerina record. Similarly, the generated serialization function (i.e. `toEdiString(...)`) can serialize generated Ballerina records into EDI text.
+`modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
-### Example
+> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) — you can import those directly without generating anything. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
-Create a new Ballerina project named `sample` and create a module named `orders` inside that project by using the below commands:
+## Generate from an X12 schema
+
+X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so you start from the X12 schema (XSD) you are entitled to use and convert it.
+
+**Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
+
+```
+$ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
+```
+
+**Step 2 — Generate Ballerina code:**
+
+```
+$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+```
+
+The result is the same shape as the EDIFACT flow: typed records and parser functions you can use right away.
+
+## Using the generated code
+
+Set up a project and a module to hold the generated code, then run `codegen` into it:
 
 ```
 $ bal new sample
 $ cd sample
 $ bal add orders
+$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 ```
 
-Create a new folder named resources in the root of the project and copy the `schema.json` and `sample.edi` files into it. At this point, the directory structure of the project would look like below:
-```
-.
-├── Ballerina.toml
-├── Dependencies.toml
-├── main.bal
-├── modules
-│   └── orders
-│       ├── Module.md
-│       ├── orders.bal
-│       ├── resources
-│       └── tests
-│           └── lib_test.bal
-└── resources
-    ├── sample.edi
-    └── schema.json
-```
-
-Ballerina records for the EDI schema in the `resources/schema.json` can be generated as follows (generated Ballerina records will be saved in `modules/order/records.bal`).
-
-Run the below command from the project root directory to generate the Ballerina parser for the above schema.
-
-```
-bal edi codegen -i resources/schema.json -o modules/orders/records.bal
-```
-
-Generated Ballerina records for the above schema are shown below:
-
-```ballerina
-public type Header_Type record {|
-   string code = "HDR";
-   string orderId?;
-   string organization?;
-   string date?;
-|};
-
-public type Items_Type record {|
-   string code = "ITM";
-   string item?;
-   int? quantity?;
-|};
-
-public type SimpleOrder record {|
-   Header_Type header;
-   Items_Type[] items = [];
-|};
-```
+The generated module exposes typed records named after the schema, plus parser functions. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`.
 
 ### Reading EDI files
 
-The generated ```fromEdiString``` function can be used to read EDI text files into the generated Ballerina record as shown below. Note that any data item in the EDI can be accessed using the record's fields, as shown in the example code.
+`fromEdiString` reads EDI text into a typed record. Any value in the EDI can then be accessed through the record's fields:
 
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
-    string ediText = check io:fileReadString("resources/sample.edi");
-    orders:SimpleOrder sample_order = check orders:fromEdiString(ediText);
-    io:println(sample_order.header.date);
+    string ediText = check io:fileReadString("resources/order.edi");
+    orders:ORDERS document = check orders:fromEdiString(ediText);
+    io:println(document);
 }
-````
+```
 
 ### Writing EDI files
 
-The generated ```toEdiString``` function can be used to serialize ```SimpleOrder``` records into EDI text as shown below:
+`toEdiString` serializes a typed record back into EDI text:
 
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
+
 public function main() returns error? {
-    orders:SimpleOrder simpleOrder = {header: {code: "HDR", orderId: "ORDER_200", organization: "ABC_Store", date: "17-05-2024"}};
-    simpleOrder.items.push({code: "ITM", item: "A680", quantity: 15}); 
-    simpleOrder.items.push({code: "ITM", item: "A530", quantity: 2}); 
-    simpleOrder.items.push({code: "ITM", item: "A500", quantity: 4});
-    string ediText = check orders:toEdiString(simpleOrder);
+    orders:ORDERS document = { /* populate the record */ };
+    string ediText = check orders:toEdiString(document);
     io:println(ediText);
 }
-````
+```
 
 ### Reading and writing EDI envelopes
 
-When the source schema is generated from a standard X12 or EDIFACT spec, it carries
-a structured `envelope` definition, and `codegen` emits additional typed wrappers for
-working with the full interchange envelope (not just the message body):
+A real EDI file is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
 
-- `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that
-  mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a
-  malformed transaction body is captured rather than aborting the whole parse (fail-safe).
-- `headersFromEdiString` — extracts just the envelope headers.
+- `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a malformed transaction body is captured rather than aborting the whole parse (fail-safe).
+- `headersFromEdiString` — extracts just the envelope headers (useful for routing).
 - `interchangeFromEdiString` — parses the full interchange into a typed `<Name>Interchange`.
 - `interchangeToEdiString` — the inverse, serializing a `<Name>Interchange` back to EDI text.
 
-For example, a package generated from the EDIFACT ORDERS spec exposes an
-`ORDERSInterchange` type whose transactions can be read and re-serialized:
-
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
-    string ediText = check io:fileReadString("resources/sample.edi");
+    string ediText = check io:fileReadString("resources/order.edi");
 
     // Parse the full envelope hierarchy into typed records.
     orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
@@ -201,252 +140,106 @@ public function main() returns error? {
     string ediOut = check orders:interchangeToEdiString(interchange);
     io:println(ediOut);
 }
-````
+```
 
-> These envelope wrappers require `ballerina/edi >= 1.6.0`; older runtimes reject the
-> `envelope` field. For envelope-aware schemas, `libgen` pins this floor via a
-> `[[dependency]]` block in the generated package's `Ballerina.toml` and prints a notice.
+> The envelope wrappers require `ballerina/edi >= 1.6.0`. For envelope-aware schemas, `libgen` pins this floor via a `[[dependency]]` block in the generated package's `Ballerina.toml` and prints a notice.
 
-## Package generation
+## Generating a library package
 
-Usually, organizations have to work with many EDI formats, and integration developers need to have a convenient way to work on EDI data with minimum effort. Ballerina EDI libraries facilitate this by allowing organizations to pack all EDI processing codes for their EDI collections into an importable package. Therefore, integration developers can simply import those libraries and convert EDI messages into Ballerina records in a single line of code.
-
-The below command can be used to generate Ballerina records, parser and util functions, and a REST connector for a given collection of EDI schemas organized into a Ballerina package:
+Organizations usually work with several EDI formats at once. Instead of running `codegen` per schema and tracking the outputs by hand, `libgen` bundles a directory of schemas into a single importable Ballerina package:
 
 ```
 bal edi libgen -p <organization-name/package-name> -i <input schema folder> -o <output folder>
 ```
 
-The Ballerina package will be generated in the output folder. This package can be built and published by issuing "bal pack" and "bal push" commands from the output folder. Then the generated package can be imported into any Ballerina project and generated utility functions of the package can be invoked to parse EDI messages into Ballerina records. 
+For example, an organization "CityMart" that handles X12 `850`, `810`, `820`, and `855` can drop those schemas into a folder and run:
 
-### Example
-
-Let's assume that an organization named "CityMart" needs to work with X12 850, 810, 820, and 855 to handle purchase orders. CityMart's integration developers can put schemas of those X12 specifications into a folder as follows:
-
-````bash
-|-- CityMart
-    |--lib
-    |--schemas
-       |--850.json
-       |--810.json
-       |--820.json
-       |--855.json
-````
-
-Then the libgen command can be used to generate a Ballerina package as shown below:
-
-````
+```
 bal edi libgen -p citymart/porder -i CityMart/schemas -o CityMart/lib
-````
+```
 
-The generated Ballerina package will look like below:
+Each schema is generated into its own module (`m850`, `m810`, …) to avoid conflicts, alongside a `Ballerina.toml`, shared utilities, and a REST connector. Build and publish the package with `bal pack` and `bal push`, then import it like any other library:
 
-````bash
-|-- CityMart
-    |--lib  
-    |--porder
-    |     |--modules
-    |	  |   |--m850
-    |	  |	  |  |--G_850.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m810
-    |	  |	  |  |--G_810.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m820
-    |	  |	  |  |--G_820.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m855
-    |	  |	    |--G_855.bal
-    |     |     |--transformer.bal
-    |	  |--Ballerina.toml
-    |	  |--Module.md
-    |	  |--Package.md
-    |	  |--porder.bal
-    |	  |--rest_connector.bal
-    |
-    |--schemas
-       |--850.json
-       |--810.json
-       |--820.json
-       |--855.json
-````
-
-As seen in the above project structure, code for each EDI schema is generated into a separate module, to prevent possible conflicts. Now it is possible to build the above project using the ```bal pack``` command and publish it into the central repository using the ```bal push``` command. Then any Ballerina project can import this package and use it to work with purchase order-related EDI files. An example of using this package for reading an 850 file and writing an 855 file is shown below:
-
-````ballerina
+```ballerina
 import ballerina/io;
 import citymart/porder.m850;
 import citymart/porder.m855;
 
 public function main() returns error? {
-    string orderText = check io:fileReadString("orders/d15_05_2023/order10.edi");
+    string orderText = check io:fileReadString("orders/order10.edi");
     m850:Purchase_Order purchaseOrder = check m850:fromEdiString(orderText);
-    ...
-    m855:Purchase_Order_Acknowledgement orderAck = {...};
-    string orderAckText = check m855:toEdiString(orderAck);
-    check io:fileWriteString("acks/d15_05_2023/ack10.edi", orderAckText);
+    // ...
+    m855:Purchase_Order_Acknowledgement orderAck = { /* ... */ };
+    string ackText = check m855:toEdiString(orderAck);
+    check io:fileWriteString("acks/ack10.edi", ackText);
 }
-````
+```
 
-It is quite common for different trading partners to use variations of standard EDI formats. In such cases, it is possible to create partner-specific schemas and generate a partner-specific Ballerina package for processing interactions with the particular partner.
+Because trading partners often use variations of a standard format, you can also generate a partner-specific package from partner-specific schemas.
 
-### Using generated EDI libraries as standalone REST services
+### Running a generated package as a REST service
 
-EDI libraries generated in the previous step can also be compiled to a jar file (using the ```bal build``` command) and executed(using the ```bal run``` command) as a standalone Ballerina service that processes EDI files via a REST interface. This is useful for microservice environments where the EDI processing functionality can be deployed as a separate microservice.
-
-For example, the "citymart" package generated in the above step can be built and executed as a jar file. Once executed, it will expose a REST service to work with X12 850, 810, 820, and 855 files. 
-
-#### Converting of X12 850 EDI text to JSON using the REST service
-
-The below REST call can be used to convert an X12 850 EDI text to JSON using the REST service generated from the "citymart" package:
+A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — handy when EDI processing should be its own microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
 
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
 --header 'Content-Type: text/plain' \
---data-raw 'GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
-ST*850*0001~
+--data-raw 'ST*850*0001~
 BEG*00*NE*4500012345**20240802~
-REF*DP*038~
-PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
-FOB*CC~
-ITD*01*3*2**30**31~
-DTM*002*20240902~
-N1*ST*SHIP TO NAME*92*SHIP TO CODE~
-N3*123 SHIP TO ADDRESS~
-N4*CITY*STATE*12345*US~
-PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
-PID*F****PRODUCT DESCRIPTION~
-PO4*1*CA*20*LB~
+PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*16*0001~
-GE*1*1~
-IEA*1*000000001~'
+SE*16*0001~'
 ```
 
-The above REST call will return a JSON response like the below:
+The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
 
-```
+## Custom EDI schemas
+
+If you work with a proprietary or non-standard format that is neither X12 nor EDIFACT, describe its structure directly in the Ballerina EDI schema format (JSON) and run `codegen` on it — no conversion step needed. A minimal schema for a simple order looks like:
+
+```json
 {
-    "X12_FunctionalGroup": {
-        "FunctionalGroupHeader": {
-            "code": "GS",
-            "GS01__FunctionalIdentifierCode": "PO",
-            "GS02__ApplicationSendersCode": "SENDERID",
-            "GS03__ApplicationReceiversCode": "RECEIVERID",
-            ... // Other fields
+    "name": "SimpleOrder",
+    "delimiters": {"segment": "~", "field": "*", "component": ":", "repetition": "^"},
+    "segments": [
+        {
+            "code": "HDR",
+            "tag": "header",
+            "minOccurances": 1,
+            "fields": [{"tag": "code"}, {"tag": "orderId"}, {"tag": "organization"}, {"tag": "date"}]
+        },
+        {
+            "code": "ITM",
+            "tag": "items",
+            "maxOccurances": -1,
+            "fields": [{"tag": "code"}, {"tag": "item"}, {"tag": "quantity", "dataType": "int"}]
         }
-        ... // Other fields
-    },
-    "InterchangeControlTrailer": {
-        "code": "IEA",
-        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
-        "IEA02__InterchangeControlNumber": 1.0
-    }
+    ]
 }
 ```
 
-#### Converting of JSON to X12 850 EDI text using the REST service
-
-The below REST call can be used to convert a JSON to X12 850 EDI text using the REST service generated from the "citymart" package:
+This parses EDI documents with one `HDR` segment (mapped to `header`) and any number of `ITM` segments (mapped to `items`), for example:
 
 ```
-curl --location 'http://localhost:9090/ediParser/objects/850' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "X12_FunctionalGroup": {
-        "FunctionalGroupHeader": {
-            "code": "GS",
-            "GS01__FunctionalIdentifierCode": "PO",
-            "GS02__ApplicationSendersCode": "SENDERID",
-            "GS03__ApplicationReceiversCode": "RECEIVERID",
-            "GS04__Date": "20240802",
-            "GS05__Time": "1705",
-            "GS06__GroupControlNumber": 1.0,
-            ... // Other fields
-        },
-        ... // Other fields
-    },
-    "InterchangeControlTrailer": {
-        "code": "IEA",
-        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
-        "IEA02__InterchangeControlNumber": 1.0
-    }
-}'
+HDR*ORDER_1201*ABC_Store*2008-01-01~
+ITM*A-250*12~
+ITM*A-45*100~
 ```
 
-The above REST call will return an X12 850 EDI text response like the below:
+Generate code from it the same way:
 
 ```
-GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
-ST*850*0001~
-BEG*00*NE*4500012345**20240802~
-REF*DP*038~
-PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
-FOB*CC~
-ITD*01*3*2**30**31~
-DTM*002*20240902~
-N1*ST*SHIP TO NAME*92*SHIP TO CODE~
-N3*123 SHIP TO ADDRESS~
-N4*CITY*STATE*12345*US~
-PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
-PID*F****PRODUCT DESCRIPTION~
-PO4*1*CA*20*LB~
-CTT*1~
-SE*16*0001~
-GE*1*1~
-IEA*1*1~
+bal edi codegen -i schema.json -o modules/orders/orders.bal
 ```
 
-## Schema conversion
+For the full schema grammar — delimiters, segment groups, fields, components, sub-components, the `envelope` declaration, and additional configuration — see the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md).
 
-Instead of writing Ballerina EDI schema from scratch, the Ballerina EDI tool also supports converting various EDI schema formats to Ballerina EDI schema format.
+### ESL schemas
 
-### X12 schema to Ballerina EDI schema
-
-X12, short for ANSI ASC X12, is a standard for electronic data interchange (EDI) in the United States. It defines the structure and format of business documents such as purchase orders, invoices, and shipping notices, allowing for seamless communication between different computer systems. X12 standards cover a wide range of industries, including healthcare, finance, retail, and manufacturing.
-
-The below command can be used to convert the X12 schema to the Ballerina EDI schema:
-
-``` 
-bal edi convertX12Schema -H <enable headers mode> -c <enable collection mode > -i <input schema path> -o <output json file/folder path> -d <segment details path>
-```
-
-Example:
+ESL (Electronic Shelf Labeling) schemas, used for retail pricing feeds, can be converted with `convertESL`, supplying the base segment definitions:
 
 ```
-$ bal edi convertX12Schema -i input/schema.xsd -o output/schema.json
-```
-
-### EDIFACT schema to Ballerina EDI schema
-
-EDIFACT, which stands for Electronic Data Interchange For Administration, Commerce, and Transport, is an international EDI standard developed by the United Nations. It's widely used in Europe and many other parts of the world. EDIFACT provides a common syntax for exchanging business documents electronically between trading partners, facilitating global trade and improving efficiency in supply chain management.
-
-The below command can be used to convert the EDIFACT schema to the Ballerina EDI schema:
-
-```
-bal edi convertEdifactSchema -v <EDIFACT version> -t <EDIFACT message type> -o <output folder>
-```
-
-Example:
-
-```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o output/schema.json
-```
-
-### ESL to Ballerina EDI schema
-
-ESL, or Electronic Shelf Labeling, is a technology used in retail stores to display product pricing and information electronically. Instead of traditional paper price tags, ESL systems use digital displays that can be updated remotely, allowing retailers to change prices in real-time and automate pricing strategies.
-
-The below command can be used to convert ESL schema to Ballerina EDI schema:
-
-```
-bal edi convertESL -b <segment definitions file path> -i <input ESL schema file/folder> -o <output file/folder>
-```
-
-Example:
-
-```
-$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o output/schema.json
+$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
 ```
 
 ## Issues and projects

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ $ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-`modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
+The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
 > **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) and can be imported directly without generating any code. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
@@ -62,23 +62,22 @@ $ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 **Step 2 — Generate Ballerina code:**
 
 ```
-$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+$ bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 The result matches the EDIFACT flow: typed records and parser functions ready for use.
 
 ## Using the generated code
 
-Set up a project and a module to hold the generated code, then run `codegen` into it:
+Create a project and generate the code into its default module:
 
 ```
 $ bal new sample
 $ cd sample
-$ bal add orders
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-The generated module exposes typed records named after the schema, plus parser functions. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`.
+The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
 
 ### Reading EDI files
 
@@ -86,11 +85,10 @@ The generated module exposes typed records named after the schema, plus parser f
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:ORDERS document = check orders:fromEdiString(ediText);
+    ORDERS document = check fromEdiString(ediText);
     io:println(document);
 }
 ```
@@ -101,11 +99,10 @@ public function main() returns error? {
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
-    orders:ORDERS document = { /* populate the record */ };
-    string ediText = check orders:toEdiString(document);
+    ORDERS document = { /* populate the record */ };
+    string ediText = check toEdiString(document);
     io:println(ediText);
 }
 ```
@@ -121,13 +118,12 @@ An EDI interchange is wrapped in an **envelope** — interchange and (for X12) f
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
 
     // Parse the full envelope hierarchy into typed records.
-    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -137,7 +133,7 @@ public function main() returns error? {
     }
 
     // Serialize a (filtered/transformed) interchange back to EDI text.
-    string ediOut = check orders:interchangeToEdiString(interchange);
+    string ediOut = check interchangeToEdiString(interchange);
     io:println(ediOut);
 }
 ```
@@ -229,7 +225,7 @@ ITM*A-45*100~
 Generate code from it the same way:
 
 ```
-bal edi codegen -i schema.json -o modules/orders/orders.bal
+bal edi codegen -i schema.json -o orders.bal
 ```
 
 For the full schema grammar — delimiters, segment groups, fields, components, sub-components, the `envelope` declaration, and additional configuration — see the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md).

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ $ bal tool pull edi
 
 EDIFACT is the international EDI standard. The tool includes the EDIFACT message specifications, so the schema is generated from the version and message type — no schema needs to be written by hand.
 
-**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
+**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`). `-o` is an output directory; the schema is written there as `<message-type>.json` (here, `resources/ORDERS.json`):
 
 ```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 ```
 
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
@@ -74,7 +74,7 @@ Create a project and generate the code into its default module:
 ```
 $ bal new sample
 $ cd sample
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The generated code uses the [`ballerina/edi`](https://github.com/ballerina-platf
 Pull the EDI tool from [Ballerina Central](https://central.ballerina.io/):
 
 ```
-$ bal tool pull edi
+bal tool pull edi
 ```
 
 ## Generate from an EDIFACT spec
@@ -36,13 +36,13 @@ EDIFACT is the international EDI standard. The tool includes the EDIFACT message
 **Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`). `-o` is an output directory; the schema is written there as `<message-type>.json` (here, `resources/ORDERS.json`):
 
 ```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
+bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 ```
 
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
@@ -56,13 +56,13 @@ X12 is the EDI standard used across North America. X12 specifications are licens
 **Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
 
 ```
-$ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
+bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 ```
 
 **Step 2 — Generate Ballerina code:**
 
 ```
-$ bal edi codegen -i resources/850-schema.json -o po.bal
+bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 The result matches the EDIFACT flow: typed records and parser functions ready for use.
@@ -72,9 +72,9 @@ The result matches the EDIFACT flow: typed records and parser functions ready fo
 Create a project and generate the code into its default module:
 
 ```
-$ bal new sample
-$ cd sample
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal new sample
+cd sample
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
@@ -126,7 +126,7 @@ public function main() returns error? {
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
-            io:println("Quarantined: ", (<error>txn.body).message());
+            io:println("Quarantined: ", txn.body.message());
             continue;
         }
         io:println(txn.body);
@@ -184,7 +184,7 @@ curl --location 'http://localhost:9090/porderParser/edis/850' \
 BEG*00*NE*4500012345**20240802~
 PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*16*0001~'
+SE*5*0001~'
 ```
 
 The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
@@ -235,7 +235,7 @@ For the full schema grammar — delimiters, segment groups, fields, components, 
 ESL (EDI Schema Language) is a schema-definition format that describes an EDI message's structure in YAML, alongside a base segment-definitions file. Convert an ESL schema into a Ballerina EDI schema with `convertESL`:
 
 ```
-$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
+bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
 ```
 
 ## Issues and projects

--- a/build-config/resources/package/Ballerina.toml
+++ b/build-config/resources/package/Ballerina.toml
@@ -6,3 +6,4 @@ authors = ["Ballerina"]
 keywords = ["edi"]
 license = ["Apache-2.0"]
 distribution = "2201.11.0"
+readme = "README.md"

--- a/edi-tools-package/Module.md
+++ b/edi-tools-package/Module.md
@@ -1,1 +1,0 @@
-Ballerina EDI tool

--- a/edi-tools-package/Package.md
+++ b/edi-tools-package/Package.md
@@ -1,1 +1,0 @@
-Ballerina EDI tool

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -27,16 +27,16 @@ $ bal tool pull edi
 
 EDIFACT is the international EDI standard. The tool includes the EDIFACT message specifications, so the schema is generated from the version and message type — no schema needs to be written by hand.
 
-**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
+**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`). `-o` is an output directory; the schema is written there as `<message-type>.json` (here, `resources/ORDERS.json`):
 
 ```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 ```
 
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
@@ -68,7 +68,7 @@ Create a project and generate the code into its default module:
 ```
 $ bal new sample
 $ cd sample
-$ bal edi codegen -i resources/orders-schema.json -o orders.bal
+$ bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -174,11 +174,14 @@ A generated package also includes a REST connector, so it can be built (`bal bui
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
 --header 'Content-Type: text/plain' \
---data-raw 'ST*850*0001~
+--data-raw 'GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
+ST*850*0001~
 BEG*00*NE*4500012345**20240802~
 PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*5*0001~'
+SE*5*0001~
+GE*1*1~
+IEA*1*000000001~'
 ```
 
 The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -36,10 +36,10 @@ $ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-`modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
+The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
 > **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) and can be imported directly without generating any code. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
@@ -56,23 +56,22 @@ $ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 **Step 2 — Generate Ballerina code:**
 
 ```
-$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+$ bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 The result matches the EDIFACT flow: typed records and parser functions ready for use.
 
 ## Using the generated code
 
-Set up a project and a module to hold the generated code, then run `codegen` into it:
+Create a project and generate the code into its default module:
 
 ```
 $ bal new sample
 $ cd sample
-$ bal add orders
-$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
+$ bal edi codegen -i resources/orders-schema.json -o orders.bal
 ```
 
-The generated module exposes typed records named after the schema, plus parser functions. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`.
+The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
 
 ### Reading EDI files
 
@@ -80,11 +79,10 @@ The generated module exposes typed records named after the schema, plus parser f
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
-    orders:ORDERS document = check orders:fromEdiString(ediText);
+    ORDERS document = check fromEdiString(ediText);
     io:println(document);
 }
 ```
@@ -95,11 +93,10 @@ public function main() returns error? {
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
-    orders:ORDERS document = { /* populate the record */ };
-    string ediText = check orders:toEdiString(document);
+    ORDERS document = { /* populate the record */ };
+    string ediText = check toEdiString(document);
     io:println(ediText);
 }
 ```
@@ -115,13 +112,12 @@ An EDI interchange is wrapped in an **envelope** — interchange and (for X12) f
 
 ```ballerina
 import ballerina/io;
-import sample.orders;
 
 public function main() returns error? {
     string ediText = check io:fileReadString("resources/order.edi");
 
     // Parse the full envelope hierarchy into typed records.
-    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
             io:println("Quarantined: ", (<error>txn.body).message());
@@ -131,7 +127,7 @@ public function main() returns error? {
     }
 
     // Serialize a (filtered/transformed) interchange back to EDI text.
-    string ediOut = check orders:interchangeToEdiString(interchange);
+    string ediOut = check interchangeToEdiString(interchange);
     io:println(ediOut);
 }
 ```
@@ -223,7 +219,7 @@ ITM*A-45*100~
 Generate code from it the same way:
 
 ```
-bal edi codegen -i schema.json -o modules/orders/orders.bal
+bal edi codegen -i schema.json -o orders.bal
 ```
 
 For the full schema grammar — delimiters, segment groups, fields, components, sub-components, the `envelope` declaration, and additional configuration — see the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md).

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -1,185 +1,124 @@
 ## Overview
 
-Electronic Data Interchange (EDI) is a technology designed to facilitate the electronic transfer of business documents among various organizations. The Ballerina EDI tool provides a set of command line tools to work with EDI files in Ballerina.
+Electronic Data Interchange (EDI) is how businesses exchange documents such as purchase orders, invoices, and shipping notices with their trading partners. Most EDI traffic follows one of two standards:
+
+- **EDIFACT** — the international UN standard, with message types such as `ORDERS`, `INVOIC`, and `DESADV`.
+- **X12** — the ANSI ASC X12 standard used across North America, with transaction sets such as `850` (purchase order), `810` (invoice), and `856` (ship notice).
+
+You do not need to learn the raw EDI wire format. Point the `bal edi` tool at the standard you already work with, and it generates the Ballerina record types and parser functions for you — so a purchase order or invoice becomes an ordinary typed record you read and write like any other Ballerina value.
+
+The tool can:
+
+- **Generate code from an EDIFACT or X12 spec** — the common case, covered first below.
+- **Bundle several schemas into a reusable library package**, optionally exposed as a REST service.
+- **Generate code from a custom schema** — for proprietary or non-standard formats.
+
+The generated code uses the [`ballerina/edi`](https://github.com/ballerina-platform/module-ballerina-edi) module at runtime.
 
 ## Installation
 
-Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/ballerina/edi/latest).
+Pull the EDI tool from [Ballerina Central](https://central.ballerina.io/):
 
 ```
 $ bal tool pull edi
 ```
 
-## Usage
+## Generate from an EDIFACT spec
 
-The tool supports three main usages as follows.
+EDIFACT is the international EDI standard. The tool already knows the EDIFACT message specifications, so there is no schema to write — you just name the version and message type.
 
-- **Code generation**: Generate Ballerina records and parser functions for a given EDI schema.
-- **Package generation**: Generates Ballerina records, parser functions, utility methods, and a REST connector for a given collection of EDI schemas and organizes those as a Ballerina package.
-- **Schema conversion**: Convert various EDI schema formats to Ballerina EDI schema format.
-
-## Define EDI schema
-
-Prior to utilizing the EDI Tools, it is crucial to define the structure of the EDI data meant for import. Developers have the option to utilize the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for guidance. This specification outlines the essential components required to describe an EDI schema, encompassing attributes such as name, delimiters, segments, field definitions, components, sub-components, and additional configuration options.
-
-As an illustrative example, consider the following EDI schema definition for a _simple order_, assumed to be stored as `schema.json`:
-
-```json
-{
-    "name": "SimpleOrder",
-    "delimiters" : {"segment" : "~", "field" : "*", "component": ":", "repetition": "^"},
-    "segments" : [
-        {
-            "code": "HDR",
-            "tag" : "header",
-            "minOccurances": 1,
-            "fields" : [{"tag": "code"}, {"tag" : "orderId"}, {"tag" : "organization"}, {"tag" : "date"}]
-        },
-        {
-            "code": "ITM",
-            "tag" : "items",
-            "maxOccurances" : -1,
-            "fields" : [{"tag": "code"}, {"tag" : "item"}, {"tag" : "quantity", "dataType" : "int"}]
-        }
-    ]
-}
-```
-
-This schema can be employed to parse EDI documents featuring one HDR segment, mapped to the _header_, and any number of ITM segments, mapped to _items_. The HDR segment incorporates three _fields_, corresponding to _orderId_, _organization_, and _date_. Each ITM segment comprises two fields, mapped to _item_ and _quantity_.
-
-Below is an example of an EDI document that can be parsed using the aforementioned schema. Let's assume that the following EDI information is saved in a file named `sample.edi`:
+**Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
 
 ```
-HDR*ORDER_1201*ABC_Store*2008-01-01~
-ITM*A-250*12~
-ITM*A-45*100~
-ITM*D-10*58~
-ITM*K-80*250~
-ITM*T-46*28~
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources/orders-schema.json
 ```
 
-## Code generation
-
-The below command can be used to generate typed Ballerina records and parser functions for a given EDI schema.
+**Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-bal edi codegen -i <input schema path> -o <output path>
+$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 ```
 
-The above command generates all Ballerina records and parser functions required for working with data in the given EDI schema and writes those into the file specified in the `output path`. The generated parser function (i.e. `fromEdiString(...)`) can read EDI text files into generated records, which can be accessed from Ballerina code similar to accessing any other Ballerina record. Similarly, the generated serialization function (i.e. `toEdiString(...)`) can serialize generated Ballerina records into EDI text.
+`modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
-### Example
+> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) — you can import those directly without generating anything. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
-Create a new Ballerina project named `sample` and create a module named `orders` inside that project by using the below commands:
+## Generate from an X12 schema
+
+X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so you start from the X12 schema (XSD) you are entitled to use and convert it.
+
+**Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
+
+```
+$ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
+```
+
+**Step 2 — Generate Ballerina code:**
+
+```
+$ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
+```
+
+The result is the same shape as the EDIFACT flow: typed records and parser functions you can use right away.
+
+## Using the generated code
+
+Set up a project and a module to hold the generated code, then run `codegen` into it:
 
 ```
 $ bal new sample
 $ cd sample
 $ bal add orders
+$ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 ```
 
-Create a new folder named resources in the root of the project and copy the `schema.json` and `sample.edi` files into it. At this point, the directory structure of the project would look like below:
-```
-.
-├── Ballerina.toml
-├── Dependencies.toml
-├── main.bal
-├── modules
-│   └── orders
-│       ├── Module.md
-│       ├── orders.bal
-│       ├── resources
-│       └── tests
-│           └── lib_test.bal
-└── resources
-    ├── sample.edi
-    └── schema.json
-```
-
-Ballerina records for the EDI schema in the `resources/schema.json` can be generated as follows (generated Ballerina records will be saved in `modules/order/records.bal`).
-
-Run the below command from the project root directory to generate the Ballerina parser for the above schema.
-
-```
-bal edi codegen -i resources/schema.json -o modules/orders/records.bal
-```
-
-Generated Ballerina records for the above schema are shown below:
-
-```ballerina
-public type Header_Type record {|
-   string code = "HDR";
-   string orderId?;
-   string organization?;
-   string date?;
-|};
-
-public type Items_Type record {|
-   string code = "ITM";
-   string item?;
-   int? quantity?;
-|};
-
-public type SimpleOrder record {|
-   Header_Type header;
-   Items_Type[] items = [];
-|};
-```
+The generated module exposes typed records named after the schema, plus parser functions. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`.
 
 ### Reading EDI files
 
-The generated ```fromEdiString``` function can be used to read EDI text files into the generated Ballerina record as shown below. Note that any data item in the EDI can be accessed using the record's fields, as shown in the example code.
+`fromEdiString` reads EDI text into a typed record. Any value in the EDI can then be accessed through the record's fields:
 
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
-    string ediText = check io:fileReadString("resources/sample.edi");
-    orders:SimpleOrder sample_order = check orders:fromEdiString(ediText);
-    io:println(sample_order.header.date);
+    string ediText = check io:fileReadString("resources/order.edi");
+    orders:ORDERS document = check orders:fromEdiString(ediText);
+    io:println(document);
 }
-````
+```
 
 ### Writing EDI files
 
-The generated ```toEdiString``` function can be used to serialize ```SimpleOrder``` records into EDI text as shown below:
+`toEdiString` serializes a typed record back into EDI text:
 
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
+
 public function main() returns error? {
-    orders:SimpleOrder simpleOrder = {header: {code: "HDR", orderId: "ORDER_200", organization: "ABC_Store", date: "17-05-2024"}};
-    simpleOrder.items.push({code: "ITM", item: "A680", quantity: 15}); 
-    simpleOrder.items.push({code: "ITM", item: "A530", quantity: 2}); 
-    simpleOrder.items.push({code: "ITM", item: "A500", quantity: 4});
-    string ediText = check orders:toEdiString(simpleOrder);
+    orders:ORDERS document = { /* populate the record */ };
+    string ediText = check orders:toEdiString(document);
     io:println(ediText);
 }
-````
+```
 
 ### Reading and writing EDI envelopes
 
-When the source schema is generated from a standard X12 or EDIFACT spec, it carries
-a structured `envelope` definition, and `codegen` emits additional typed wrappers for
-working with the full interchange envelope (not just the message body):
+A real EDI file is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
 
-- `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that
-  mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a
-  malformed transaction body is captured rather than aborting the whole parse (fail-safe).
-- `headersFromEdiString` — extracts just the envelope headers.
+- `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a malformed transaction body is captured rather than aborting the whole parse (fail-safe).
+- `headersFromEdiString` — extracts just the envelope headers (useful for routing).
 - `interchangeFromEdiString` — parses the full interchange into a typed `<Name>Interchange`.
 - `interchangeToEdiString` — the inverse, serializing a `<Name>Interchange` back to EDI text.
 
-For example, a package generated from the EDIFACT ORDERS spec exposes an
-`ORDERSInterchange` type whose transactions can be read and re-serialized:
-
-````ballerina
+```ballerina
 import ballerina/io;
 import sample.orders;
 
 public function main() returns error? {
-    string ediText = check io:fileReadString("resources/sample.edi");
+    string ediText = check io:fileReadString("resources/order.edi");
 
     // Parse the full envelope hierarchy into typed records.
     orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
@@ -195,251 +134,105 @@ public function main() returns error? {
     string ediOut = check orders:interchangeToEdiString(interchange);
     io:println(ediOut);
 }
-````
+```
 
-> These envelope wrappers require `ballerina/edi >= 1.6.0`; older runtimes reject the
-> `envelope` field. For envelope-aware schemas, `libgen` pins this floor via a
-> `[[dependency]]` block in the generated package's `Ballerina.toml` and prints a notice.
+> The envelope wrappers require `ballerina/edi >= 1.6.0`. For envelope-aware schemas, `libgen` pins this floor via a `[[dependency]]` block in the generated package's `Ballerina.toml` and prints a notice.
 
-## Package generation
+## Generating a library package
 
-Usually, organizations have to work with many EDI formats, and integration developers need to have a convenient way to work on EDI data with minimum effort. Ballerina EDI libraries facilitate this by allowing organizations to pack all EDI processing codes for their EDI collections into an importable package. Therefore, integration developers can simply import those libraries and convert EDI messages into Ballerina records in a single line of code.
-
-The below command can be used to generate Ballerina records, parser and util functions, and a REST connector for a given collection of EDI schemas organized into a Ballerina package:
+Organizations usually work with several EDI formats at once. Instead of running `codegen` per schema and tracking the outputs by hand, `libgen` bundles a directory of schemas into a single importable Ballerina package:
 
 ```
 bal edi libgen -p <organization-name/package-name> -i <input schema folder> -o <output folder>
 ```
 
-The Ballerina package will be generated in the output folder. This package can be built and published by issuing "bal pack" and "bal push" commands from the output folder. Then the generated package can be imported into any Ballerina project and generated utility functions of the package can be invoked to parse EDI messages into Ballerina records. 
+For example, an organization "CityMart" that handles X12 `850`, `810`, `820`, and `855` can drop those schemas into a folder and run:
 
-### Example
-
-Let's assume that an organization named "CityMart" needs to work with X12 850, 810, 820, and 855 to handle purchase orders. CityMart's integration developers can put schemas of those X12 specifications into a folder as follows:
-
-````bash
-|-- CityMart
-    |--lib
-    |--schemas
-       |--850.json
-       |--810.json
-       |--820.json
-       |--855.json
-````
-
-Then the libgen command can be used to generate a Ballerina package as shown below:
-
-````
+```
 bal edi libgen -p citymart/porder -i CityMart/schemas -o CityMart/lib
-````
+```
 
-The generated Ballerina package will look like below:
+Each schema is generated into its own module (`m850`, `m810`, …) to avoid conflicts, alongside a `Ballerina.toml`, shared utilities, and a REST connector. Build and publish the package with `bal pack` and `bal push`, then import it like any other library:
 
-````bash
-|-- CityMart
-    |--lib  
-    |--porder
-    |     |--modules
-    |	  |   |--m850
-    |	  |	  |  |--G_850.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m810
-    |	  |	  |  |--G_810.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m820
-    |	  |	  |  |--G_820.bal
-    |     |   |  |--transformer.bal
-    |	  |	  |--m855
-    |	  |	    |--G_855.bal
-    |     |     |--transformer.bal
-    |	  |--Ballerina.toml
-    |	  |--Module.md
-    |	  |--Package.md
-    |	  |--porder.bal
-    |	  |--rest_connector.bal
-    |
-    |--schemas
-       |--850.json
-       |--810.json
-       |--820.json
-       |--855.json
-````
-
-As seen in the above project structure, code for each EDI schema is generated into a separate module, to prevent possible conflicts. Now it is possible to build the above project using the ```bal pack``` command and publish it into the central repository using the ```bal push``` command. Then any Ballerina project can import this package and use it to work with purchase order-related EDI files. An example of using this package for reading an 850 file and writing an 855 file is shown below:
-
-````ballerina
+```ballerina
 import ballerina/io;
 import citymart/porder.m850;
 import citymart/porder.m855;
 
 public function main() returns error? {
-    string orderText = check io:fileReadString("orders/d15_05_2023/order10.edi");
+    string orderText = check io:fileReadString("orders/order10.edi");
     m850:Purchase_Order purchaseOrder = check m850:fromEdiString(orderText);
-    ...
-    m855:Purchase_Order_Acknowledgement orderAck = {...};
-    string orderAckText = check m855:toEdiString(orderAck);
-    check io:fileWriteString("acks/d15_05_2023/ack10.edi", orderAckText);
+    // ...
+    m855:Purchase_Order_Acknowledgement orderAck = { /* ... */ };
+    string ackText = check m855:toEdiString(orderAck);
+    check io:fileWriteString("acks/ack10.edi", ackText);
 }
-````
+```
 
-It is quite common for different trading partners to use variations of standard EDI formats. In such cases, it is possible to create partner-specific schemas and generate a partner-specific Ballerina package for processing interactions with the particular partner.
+Because trading partners often use variations of a standard format, you can also generate a partner-specific package from partner-specific schemas.
 
-### Using generated EDI libraries as standalone REST services
+### Running a generated package as a REST service
 
-EDI libraries generated in the previous step can also be compiled to a jar file (using the ```bal build``` command) and executed(using the ```bal run``` command) as a standalone Ballerina service that processes EDI files via a REST interface. This is useful for microservice environments where the EDI processing functionality can be deployed as a separate microservice.
-
-For example, the "citymart" package generated in the above step can be built and executed as a jar file. Once executed, it will expose a REST service to work with X12 850, 810, 820, and 855 files. 
-
-#### Converting of X12 850 EDI text to JSON using the REST service
-
-The below REST call can be used to convert an X12 850 EDI text to JSON using the REST service generated from the "citymart" package:
+A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — handy when EDI processing should be its own microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
 
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
 --header 'Content-Type: text/plain' \
---data-raw 'GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
-ST*850*0001~
+--data-raw 'ST*850*0001~
 BEG*00*NE*4500012345**20240802~
-REF*DP*038~
-PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
-FOB*CC~
-ITD*01*3*2**30**31~
-DTM*002*20240902~
-N1*ST*SHIP TO NAME*92*SHIP TO CODE~
-N3*123 SHIP TO ADDRESS~
-N4*CITY*STATE*12345*US~
-PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
-PID*F****PRODUCT DESCRIPTION~
-PO4*1*CA*20*LB~
+PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*16*0001~
-GE*1*1~
-IEA*1*000000001~'
+SE*16*0001~'
 ```
 
-The above REST call will return a JSON response like the below:
+The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
 
-```
+## Custom EDI schemas
+
+If you work with a proprietary or non-standard format that is neither X12 nor EDIFACT, describe its structure directly in the Ballerina EDI schema format (JSON) and run `codegen` on it — no conversion step needed. A minimal schema for a simple order looks like:
+
+```json
 {
-    "X12_FunctionalGroup": {
-        "FunctionalGroupHeader": {
-            "code": "GS",
-            "GS01__FunctionalIdentifierCode": "PO",
-            "GS02__ApplicationSendersCode": "SENDERID",
-            "GS03__ApplicationReceiversCode": "RECEIVERID",
-            ... // Other fields
+    "name": "SimpleOrder",
+    "delimiters": {"segment": "~", "field": "*", "component": ":", "repetition": "^"},
+    "segments": [
+        {
+            "code": "HDR",
+            "tag": "header",
+            "minOccurances": 1,
+            "fields": [{"tag": "code"}, {"tag": "orderId"}, {"tag": "organization"}, {"tag": "date"}]
+        },
+        {
+            "code": "ITM",
+            "tag": "items",
+            "maxOccurances": -1,
+            "fields": [{"tag": "code"}, {"tag": "item"}, {"tag": "quantity", "dataType": "int"}]
         }
-        ... // Other fields
-    },
-    "InterchangeControlTrailer": {
-        "code": "IEA",
-        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
-        "IEA02__InterchangeControlNumber": 1.0
-    }
+    ]
 }
 ```
 
-#### Converting of JSON to X12 850 EDI text using the REST service
-
-The below REST call can be used to convert a JSON to X12 850 EDI text using the REST service generated from the "citymart" package:
+This parses EDI documents with one `HDR` segment (mapped to `header`) and any number of `ITM` segments (mapped to `items`), for example:
 
 ```
-curl --location 'http://localhost:9090/ediParser/objects/850' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "X12_FunctionalGroup": {
-        "FunctionalGroupHeader": {
-            "code": "GS",
-            "GS01__FunctionalIdentifierCode": "PO",
-            "GS02__ApplicationSendersCode": "SENDERID",
-            "GS03__ApplicationReceiversCode": "RECEIVERID",
-            "GS04__Date": "20240802",
-            "GS05__Time": "1705",
-            "GS06__GroupControlNumber": 1.0,
-            ... // Other fields
-        },
-        ... // Other fields
-    },
-    "InterchangeControlTrailer": {
-        "code": "IEA",
-        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
-        "IEA02__InterchangeControlNumber": 1.0
-    }
-}'
+HDR*ORDER_1201*ABC_Store*2008-01-01~
+ITM*A-250*12~
+ITM*A-45*100~
 ```
 
-The above REST call will return an X12 850 EDI text response like the below:
+Generate code from it the same way:
 
 ```
-GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
-ST*850*0001~
-BEG*00*NE*4500012345**20240802~
-REF*DP*038~
-PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
-FOB*CC~
-ITD*01*3*2**30**31~
-DTM*002*20240902~
-N1*ST*SHIP TO NAME*92*SHIP TO CODE~
-N3*123 SHIP TO ADDRESS~
-N4*CITY*STATE*12345*US~
-PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
-PID*F****PRODUCT DESCRIPTION~
-PO4*1*CA*20*LB~
-CTT*1~
-SE*16*0001~
-GE*1*1~
-IEA*1*1~
+bal edi codegen -i schema.json -o modules/orders/orders.bal
 ```
 
-## Schema conversion
+For the full schema grammar — delimiters, segment groups, fields, components, sub-components, the `envelope` declaration, and additional configuration — see the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md).
 
-Instead of writing Ballerina EDI schema from scratch, the Ballerina EDI tool also supports converting various EDI schema formats to Ballerina EDI schema format.
+### ESL schemas
 
-### X12 schema to Ballerina EDI schema
-
-X12, short for ANSI ASC X12, is a standard for electronic data interchange (EDI) in the United States. It defines the structure and format of business documents such as purchase orders, invoices, and shipping notices, allowing for seamless communication between different computer systems. X12 standards cover a wide range of industries, including healthcare, finance, retail, and manufacturing.
-
-The below command can be used to convert the X12 schema to the Ballerina EDI schema:
-
-``` 
-bal edi convertX12Schema -H <enable headers mode> -c <enable collection mode > -i <input schema path> -o <output json file/folder path> -d <segment details path>
-```
-
-Example:
+ESL (Electronic Shelf Labeling) schemas, used for retail pricing feeds, can be converted with `convertESL`, supplying the base segment definitions:
 
 ```
-$ bal edi convertX12Schema -i input/schema.xsd -o output/schema.json
-```
-
-### EDIFACT schema to Ballerina EDI schema
-
-EDIFACT, which stands for Electronic Data Interchange For Administration, Commerce, and Transport, is an international EDI standard developed by the United Nations. It's widely used in Europe and many other parts of the world. EDIFACT provides a common syntax for exchanging business documents electronically between trading partners, facilitating global trade and improving efficiency in supply chain management.
-
-The below command can be used to convert the EDIFACT schema to the Ballerina EDI schema:
-
-```
-bal edi convertEdifactSchema -v <EDIFACT version> -t <EDIFACT message type> -o <output folder>
-```
-
-Example:
-
-```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o output/schema.json
-```
-
-### ESL to Ballerina EDI schema
-
-ESL, or Electronic Shelf Labeling, is a technology used in retail stores to display product pricing and information electronically. Instead of traditional paper price tags, ESL systems use digital displays that can be updated remotely, allowing retailers to change prices in real-time and automate pricing strategies.
-
-The below command can be used to convert ESL schema to Ballerina EDI schema:
-
-```
-bal edi convertESL -b <segment definitions file path> -i <input ESL schema file/folder> -o <output file/folder>
-```
-
-Example:
-
-```
-$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o output/schema.json
+$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
 ```
 

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -226,7 +226,7 @@ For the full schema grammar — delimiters, segment groups, fields, components, 
 
 ### ESL schemas
 
-ESL (Electronic Shelf Labeling) schemas, used for retail pricing feeds, can be converted with `convertESL`, supplying the base segment definitions:
+ESL (EDI Schema Language) is a schema-definition format that describes an EDI message's structure in YAML, alongside a base segment-definitions file. Convert an ESL schema into a Ballerina EDI schema with `convertESL`:
 
 ```
 $ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -20,7 +20,7 @@ The generated code uses the [`ballerina/edi`](https://github.com/ballerina-platf
 Pull the EDI tool from [Ballerina Central](https://central.ballerina.io/):
 
 ```
-$ bal tool pull edi
+bal tool pull edi
 ```
 
 ## Generate from an EDIFACT spec
@@ -30,13 +30,13 @@ EDIFACT is the international EDI standard. The tool includes the EDIFACT message
 **Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`). `-o` is an output directory; the schema is written there as `<message-type>.json` (here, `resources/ORDERS.json`):
 
 ```
-$ bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
+bal edi convertEdifactSchema -v d03a -t ORDERS -o resources
 ```
 
 **Step 2 — Generate Ballerina records and parser functions:**
 
 ```
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The default module now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
@@ -50,13 +50,13 @@ X12 is the EDI standard used across North America. X12 specifications are licens
 **Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
 
 ```
-$ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
+bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 ```
 
 **Step 2 — Generate Ballerina code:**
 
 ```
-$ bal edi codegen -i resources/850-schema.json -o po.bal
+bal edi codegen -i resources/850-schema.json -o po.bal
 ```
 
 The result matches the EDIFACT flow: typed records and parser functions ready for use.
@@ -66,9 +66,9 @@ The result matches the EDIFACT flow: typed records and parser functions ready fo
 Create a project and generate the code into its default module:
 
 ```
-$ bal new sample
-$ cd sample
-$ bal edi codegen -i resources/ORDERS.json -o orders.bal
+bal new sample
+cd sample
+bal edi codegen -i resources/ORDERS.json -o orders.bal
 ```
 
 The generated code exposes typed records named after the schema, plus parser functions, in the default module. For an `ORDERS` schema, the body record is `ORDERS` and the interchange wrapper is `ORDERSInterchange`. For larger projects, the generated EDI code can live in its own package within a Ballerina workspace alongside your integration.
@@ -120,7 +120,7 @@ public function main() returns error? {
     ORDERSInterchange interchange = check interchangeFromEdiString(ediText);
     foreach var txn in interchange.transactions {
         if txn.body is error {
-            io:println("Quarantined: ", (<error>txn.body).message());
+            io:println("Quarantined: ", txn.body.message());
             continue;
         }
         io:println(txn.body);
@@ -178,7 +178,7 @@ curl --location 'http://localhost:9090/porderParser/edis/850' \
 BEG*00*NE*4500012345**20240802~
 PO1*1*10*EA*15.00**BP*123456789012~
 CTT*1~
-SE*16*0001~'
+SE*5*0001~'
 ```
 
 The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
@@ -229,6 +229,6 @@ For the full schema grammar — delimiters, segment groups, fields, components, 
 ESL (EDI Schema Language) is a schema-definition format that describes an EDI message's structure in YAML, alongside a base segment-definitions file. Convert an ESL schema into a Ballerina EDI schema with `convertESL`:
 
 ```
-$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
+bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o resources/schema.json
 ```
 

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -1,0 +1,445 @@
+## Overview
+
+Electronic Data Interchange (EDI) is a technology designed to facilitate the electronic transfer of business documents among various organizations. The Ballerina EDI tool provides a set of command line tools to work with EDI files in Ballerina.
+
+## Installation
+
+Execute the command below to pull the EDI tool from [Ballerina Central](https://central.ballerina.io/ballerina/edi/latest).
+
+```
+$ bal tool pull edi
+```
+
+## Usage
+
+The tool supports three main usages as follows.
+
+- **Code generation**: Generate Ballerina records and parser functions for a given EDI schema.
+- **Package generation**: Generates Ballerina records, parser functions, utility methods, and a REST connector for a given collection of EDI schemas and organizes those as a Ballerina package.
+- **Schema conversion**: Convert various EDI schema formats to Ballerina EDI schema format.
+
+## Define EDI schema
+
+Prior to utilizing the EDI Tools, it is crucial to define the structure of the EDI data meant for import. Developers have the option to utilize the [Ballerina EDI Schema Specification](https://github.com/ballerina-platform/module-ballerina-edi/blob/main/docs/specs/SchemaSpecification.md) for guidance. This specification outlines the essential components required to describe an EDI schema, encompassing attributes such as name, delimiters, segments, field definitions, components, sub-components, and additional configuration options.
+
+As an illustrative example, consider the following EDI schema definition for a _simple order_, assumed to be stored as `schema.json`:
+
+```json
+{
+    "name": "SimpleOrder",
+    "delimiters" : {"segment" : "~", "field" : "*", "component": ":", "repetition": "^"},
+    "segments" : [
+        {
+            "code": "HDR",
+            "tag" : "header",
+            "minOccurances": 1,
+            "fields" : [{"tag": "code"}, {"tag" : "orderId"}, {"tag" : "organization"}, {"tag" : "date"}]
+        },
+        {
+            "code": "ITM",
+            "tag" : "items",
+            "maxOccurances" : -1,
+            "fields" : [{"tag": "code"}, {"tag" : "item"}, {"tag" : "quantity", "dataType" : "int"}]
+        }
+    ]
+}
+```
+
+This schema can be employed to parse EDI documents featuring one HDR segment, mapped to the _header_, and any number of ITM segments, mapped to _items_. The HDR segment incorporates three _fields_, corresponding to _orderId_, _organization_, and _date_. Each ITM segment comprises two fields, mapped to _item_ and _quantity_.
+
+Below is an example of an EDI document that can be parsed using the aforementioned schema. Let's assume that the following EDI information is saved in a file named `sample.edi`:
+
+```
+HDR*ORDER_1201*ABC_Store*2008-01-01~
+ITM*A-250*12~
+ITM*A-45*100~
+ITM*D-10*58~
+ITM*K-80*250~
+ITM*T-46*28~
+```
+
+## Code generation
+
+The below command can be used to generate typed Ballerina records and parser functions for a given EDI schema.
+
+```
+bal edi codegen -i <input schema path> -o <output path>
+```
+
+The above command generates all Ballerina records and parser functions required for working with data in the given EDI schema and writes those into the file specified in the `output path`. The generated parser function (i.e. `fromEdiString(...)`) can read EDI text files into generated records, which can be accessed from Ballerina code similar to accessing any other Ballerina record. Similarly, the generated serialization function (i.e. `toEdiString(...)`) can serialize generated Ballerina records into EDI text.
+
+### Example
+
+Create a new Ballerina project named `sample` and create a module named `orders` inside that project by using the below commands:
+
+```
+$ bal new sample
+$ cd sample
+$ bal add orders
+```
+
+Create a new folder named resources in the root of the project and copy the `schema.json` and `sample.edi` files into it. At this point, the directory structure of the project would look like below:
+```
+.
+├── Ballerina.toml
+├── Dependencies.toml
+├── main.bal
+├── modules
+│   └── orders
+│       ├── Module.md
+│       ├── orders.bal
+│       ├── resources
+│       └── tests
+│           └── lib_test.bal
+└── resources
+    ├── sample.edi
+    └── schema.json
+```
+
+Ballerina records for the EDI schema in the `resources/schema.json` can be generated as follows (generated Ballerina records will be saved in `modules/order/records.bal`).
+
+Run the below command from the project root directory to generate the Ballerina parser for the above schema.
+
+```
+bal edi codegen -i resources/schema.json -o modules/orders/records.bal
+```
+
+Generated Ballerina records for the above schema are shown below:
+
+```ballerina
+public type Header_Type record {|
+   string code = "HDR";
+   string orderId?;
+   string organization?;
+   string date?;
+|};
+
+public type Items_Type record {|
+   string code = "ITM";
+   string item?;
+   int? quantity?;
+|};
+
+public type SimpleOrder record {|
+   Header_Type header;
+   Items_Type[] items = [];
+|};
+```
+
+### Reading EDI files
+
+The generated ```fromEdiString``` function can be used to read EDI text files into the generated Ballerina record as shown below. Note that any data item in the EDI can be accessed using the record's fields, as shown in the example code.
+
+````ballerina
+import ballerina/io;
+import sample.orders;
+
+public function main() returns error? {
+    string ediText = check io:fileReadString("resources/sample.edi");
+    orders:SimpleOrder sample_order = check orders:fromEdiString(ediText);
+    io:println(sample_order.header.date);
+}
+````
+
+### Writing EDI files
+
+The generated ```toEdiString``` function can be used to serialize ```SimpleOrder``` records into EDI text as shown below:
+
+````ballerina
+import ballerina/io;
+import sample.orders;
+public function main() returns error? {
+    orders:SimpleOrder simpleOrder = {header: {code: "HDR", orderId: "ORDER_200", organization: "ABC_Store", date: "17-05-2024"}};
+    simpleOrder.items.push({code: "ITM", item: "A680", quantity: 15}); 
+    simpleOrder.items.push({code: "ITM", item: "A530", quantity: 2}); 
+    simpleOrder.items.push({code: "ITM", item: "A500", quantity: 4});
+    string ediText = check orders:toEdiString(simpleOrder);
+    io:println(ediText);
+}
+````
+
+### Reading and writing EDI envelopes
+
+When the source schema is generated from a standard X12 or EDIFACT spec, it carries
+a structured `envelope` definition, and `codegen` emits additional typed wrappers for
+working with the full interchange envelope (not just the message body):
+
+- `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that
+  mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a
+  malformed transaction body is captured rather than aborting the whole parse (fail-safe).
+- `headersFromEdiString` — extracts just the envelope headers.
+- `interchangeFromEdiString` — parses the full interchange into a typed `<Name>Interchange`.
+- `interchangeToEdiString` — the inverse, serializing a `<Name>Interchange` back to EDI text.
+
+For example, a package generated from the EDIFACT ORDERS spec exposes an
+`ORDERSInterchange` type whose transactions can be read and re-serialized:
+
+````ballerina
+import ballerina/io;
+import sample.orders;
+
+public function main() returns error? {
+    string ediText = check io:fileReadString("resources/sample.edi");
+
+    // Parse the full envelope hierarchy into typed records.
+    orders:ORDERSInterchange interchange = check orders:interchangeFromEdiString(ediText);
+    foreach var txn in interchange.transactions {
+        if txn.body is error {
+            io:println("Quarantined: ", (<error>txn.body).message());
+            continue;
+        }
+        io:println(txn.body);
+    }
+
+    // Serialize a (filtered/transformed) interchange back to EDI text.
+    string ediOut = check orders:interchangeToEdiString(interchange);
+    io:println(ediOut);
+}
+````
+
+> These envelope wrappers require `ballerina/edi >= 1.6.0`; older runtimes reject the
+> `envelope` field. For envelope-aware schemas, `libgen` pins this floor via a
+> `[[dependency]]` block in the generated package's `Ballerina.toml` and prints a notice.
+
+## Package generation
+
+Usually, organizations have to work with many EDI formats, and integration developers need to have a convenient way to work on EDI data with minimum effort. Ballerina EDI libraries facilitate this by allowing organizations to pack all EDI processing codes for their EDI collections into an importable package. Therefore, integration developers can simply import those libraries and convert EDI messages into Ballerina records in a single line of code.
+
+The below command can be used to generate Ballerina records, parser and util functions, and a REST connector for a given collection of EDI schemas organized into a Ballerina package:
+
+```
+bal edi libgen -p <organization-name/package-name> -i <input schema folder> -o <output folder>
+```
+
+The Ballerina package will be generated in the output folder. This package can be built and published by issuing "bal pack" and "bal push" commands from the output folder. Then the generated package can be imported into any Ballerina project and generated utility functions of the package can be invoked to parse EDI messages into Ballerina records. 
+
+### Example
+
+Let's assume that an organization named "CityMart" needs to work with X12 850, 810, 820, and 855 to handle purchase orders. CityMart's integration developers can put schemas of those X12 specifications into a folder as follows:
+
+````bash
+|-- CityMart
+    |--lib
+    |--schemas
+       |--850.json
+       |--810.json
+       |--820.json
+       |--855.json
+````
+
+Then the libgen command can be used to generate a Ballerina package as shown below:
+
+````
+bal edi libgen -p citymart/porder -i CityMart/schemas -o CityMart/lib
+````
+
+The generated Ballerina package will look like below:
+
+````bash
+|-- CityMart
+    |--lib  
+    |--porder
+    |     |--modules
+    |	  |   |--m850
+    |	  |	  |  |--G_850.bal
+    |     |   |  |--transformer.bal
+    |	  |	  |--m810
+    |	  |	  |  |--G_810.bal
+    |     |   |  |--transformer.bal
+    |	  |	  |--m820
+    |	  |	  |  |--G_820.bal
+    |     |   |  |--transformer.bal
+    |	  |	  |--m855
+    |	  |	    |--G_855.bal
+    |     |     |--transformer.bal
+    |	  |--Ballerina.toml
+    |	  |--Module.md
+    |	  |--Package.md
+    |	  |--porder.bal
+    |	  |--rest_connector.bal
+    |
+    |--schemas
+       |--850.json
+       |--810.json
+       |--820.json
+       |--855.json
+````
+
+As seen in the above project structure, code for each EDI schema is generated into a separate module, to prevent possible conflicts. Now it is possible to build the above project using the ```bal pack``` command and publish it into the central repository using the ```bal push``` command. Then any Ballerina project can import this package and use it to work with purchase order-related EDI files. An example of using this package for reading an 850 file and writing an 855 file is shown below:
+
+````ballerina
+import ballerina/io;
+import citymart/porder.m850;
+import citymart/porder.m855;
+
+public function main() returns error? {
+    string orderText = check io:fileReadString("orders/d15_05_2023/order10.edi");
+    m850:Purchase_Order purchaseOrder = check m850:fromEdiString(orderText);
+    ...
+    m855:Purchase_Order_Acknowledgement orderAck = {...};
+    string orderAckText = check m855:toEdiString(orderAck);
+    check io:fileWriteString("acks/d15_05_2023/ack10.edi", orderAckText);
+}
+````
+
+It is quite common for different trading partners to use variations of standard EDI formats. In such cases, it is possible to create partner-specific schemas and generate a partner-specific Ballerina package for processing interactions with the particular partner.
+
+### Using generated EDI libraries as standalone REST services
+
+EDI libraries generated in the previous step can also be compiled to a jar file (using the ```bal build``` command) and executed(using the ```bal run``` command) as a standalone Ballerina service that processes EDI files via a REST interface. This is useful for microservice environments where the EDI processing functionality can be deployed as a separate microservice.
+
+For example, the "citymart" package generated in the above step can be built and executed as a jar file. Once executed, it will expose a REST service to work with X12 850, 810, 820, and 855 files. 
+
+#### Converting of X12 850 EDI text to JSON using the REST service
+
+The below REST call can be used to convert an X12 850 EDI text to JSON using the REST service generated from the "citymart" package:
+
+```
+curl --location 'http://localhost:9090/porderParser/edis/850' \
+--header 'Content-Type: text/plain' \
+--data-raw 'GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
+ST*850*0001~
+BEG*00*NE*4500012345**20240802~
+REF*DP*038~
+PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
+FOB*CC~
+ITD*01*3*2**30**31~
+DTM*002*20240902~
+N1*ST*SHIP TO NAME*92*SHIP TO CODE~
+N3*123 SHIP TO ADDRESS~
+N4*CITY*STATE*12345*US~
+PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
+PID*F****PRODUCT DESCRIPTION~
+PO4*1*CA*20*LB~
+CTT*1~
+SE*16*0001~
+GE*1*1~
+IEA*1*000000001~'
+```
+
+The above REST call will return a JSON response like the below:
+
+```
+{
+    "X12_FunctionalGroup": {
+        "FunctionalGroupHeader": {
+            "code": "GS",
+            "GS01__FunctionalIdentifierCode": "PO",
+            "GS02__ApplicationSendersCode": "SENDERID",
+            "GS03__ApplicationReceiversCode": "RECEIVERID",
+            ... // Other fields
+        }
+        ... // Other fields
+    },
+    "InterchangeControlTrailer": {
+        "code": "IEA",
+        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
+        "IEA02__InterchangeControlNumber": 1.0
+    }
+}
+```
+
+#### Converting of JSON to X12 850 EDI text using the REST service
+
+The below REST call can be used to convert a JSON to X12 850 EDI text using the REST service generated from the "citymart" package:
+
+```
+curl --location 'http://localhost:9090/ediParser/objects/850' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "X12_FunctionalGroup": {
+        "FunctionalGroupHeader": {
+            "code": "GS",
+            "GS01__FunctionalIdentifierCode": "PO",
+            "GS02__ApplicationSendersCode": "SENDERID",
+            "GS03__ApplicationReceiversCode": "RECEIVERID",
+            "GS04__Date": "20240802",
+            "GS05__Time": "1705",
+            "GS06__GroupControlNumber": 1.0,
+            ... // Other fields
+        },
+        ... // Other fields
+    },
+    "InterchangeControlTrailer": {
+        "code": "IEA",
+        "IEA01__NumberofIncludedFunctionalGroups": 1.0,
+        "IEA02__InterchangeControlNumber": 1.0
+    }
+}'
+```
+
+The above REST call will return an X12 850 EDI text response like the below:
+
+```
+GS*PO*SENDERID*RECEIVERID*20240802*1705*1*X*004010~
+ST*850*0001~
+BEG*00*NE*4500012345**20240802~
+REF*DP*038~
+PER*BD*John Doe*TE*1234567890*EM*john.doe@example.com~
+FOB*CC~
+ITD*01*3*2**30**31~
+DTM*002*20240902~
+N1*ST*SHIP TO NAME*92*SHIP TO CODE~
+N3*123 SHIP TO ADDRESS~
+N4*CITY*STATE*12345*US~
+PO1*1*10*EA*15.00**BP*123456789012*VP*9876543210*UP*123456789012~
+PID*F****PRODUCT DESCRIPTION~
+PO4*1*CA*20*LB~
+CTT*1~
+SE*16*0001~
+GE*1*1~
+IEA*1*1~
+```
+
+## Schema conversion
+
+Instead of writing Ballerina EDI schema from scratch, the Ballerina EDI tool also supports converting various EDI schema formats to Ballerina EDI schema format.
+
+### X12 schema to Ballerina EDI schema
+
+X12, short for ANSI ASC X12, is a standard for electronic data interchange (EDI) in the United States. It defines the structure and format of business documents such as purchase orders, invoices, and shipping notices, allowing for seamless communication between different computer systems. X12 standards cover a wide range of industries, including healthcare, finance, retail, and manufacturing.
+
+The below command can be used to convert the X12 schema to the Ballerina EDI schema:
+
+``` 
+bal edi convertX12Schema -H <enable headers mode> -c <enable collection mode > -i <input schema path> -o <output json file/folder path> -d <segment details path>
+```
+
+Example:
+
+```
+$ bal edi convertX12Schema -i input/schema.xsd -o output/schema.json
+```
+
+### EDIFACT schema to Ballerina EDI schema
+
+EDIFACT, which stands for Electronic Data Interchange For Administration, Commerce, and Transport, is an international EDI standard developed by the United Nations. It's widely used in Europe and many other parts of the world. EDIFACT provides a common syntax for exchanging business documents electronically between trading partners, facilitating global trade and improving efficiency in supply chain management.
+
+The below command can be used to convert the EDIFACT schema to the Ballerina EDI schema:
+
+```
+bal edi convertEdifactSchema -v <EDIFACT version> -t <EDIFACT message type> -o <output folder>
+```
+
+Example:
+
+```
+$ bal edi convertEdifactSchema -v d03a -t ORDERS -o output/schema.json
+```
+
+### ESL to Ballerina EDI schema
+
+ESL, or Electronic Shelf Labeling, is a technology used in retail stores to display product pricing and information electronically. Instead of traditional paper price tags, ESL systems use digital displays that can be updated remotely, allowing retailers to change prices in real-time and automate pricing strategies.
+
+The below command can be used to convert ESL schema to Ballerina EDI schema:
+
+```
+bal edi convertESL -b <segment definitions file path> -i <input ESL schema file/folder> -o <output file/folder>
+```
+
+Example:
+
+```
+$ bal edi convertESL -b segment_definitions.yaml -i esl_schema.esl -o output/schema.json
+```
+

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -5,11 +5,11 @@ Electronic Data Interchange (EDI) is how businesses exchange documents such as p
 - **EDIFACT** — the international UN standard, with message types such as `ORDERS`, `INVOIC`, and `DESADV`.
 - **X12** — the ANSI ASC X12 standard used across North America, with transaction sets such as `850` (purchase order), `810` (invoice), and `856` (ship notice).
 
-You do not need to learn the raw EDI wire format. Point the `bal edi` tool at the standard you already work with, and it generates the Ballerina record types and parser functions for you — so a purchase order or invoice becomes an ordinary typed record you read and write like any other Ballerina value.
+The `bal edi` tool generates Ballerina record types and parser functions from an EDI standard's specification, so EDI documents can be processed as typed Ballerina records rather than parsed by hand.
 
 The tool can:
 
-- **Generate code from an EDIFACT or X12 spec** — the common case, covered first below.
+- **Generate code from an EDIFACT or X12 spec** — the most common case.
 - **Bundle several schemas into a reusable library package**, optionally exposed as a REST service.
 - **Generate code from a custom schema** — for proprietary or non-standard formats.
 
@@ -25,7 +25,7 @@ $ bal tool pull edi
 
 ## Generate from an EDIFACT spec
 
-EDIFACT is the international EDI standard. The tool already knows the EDIFACT message specifications, so there is no schema to write — you just name the version and message type.
+EDIFACT is the international EDI standard. The tool includes the EDIFACT message specifications, so the schema is generated from the version and message type — no schema needs to be written by hand.
 
 **Step 1 — Convert the spec into a Ballerina EDI schema.** Use `-v` for the EDIFACT version (e.g. `d03a`) and `-t` for the message type (e.g. `ORDERS`, `INVOIC`):
 
@@ -41,11 +41,11 @@ $ bal edi codegen -i resources/orders-schema.json -o modules/orders/orders.bal
 
 `modules/orders` now contains typed records plus `fromEdiString` / `toEdiString`. Because EDIFACT documents carry an envelope, the tool also emits `interchangeFromEdiString` / `interchangeToEdiString`. See [Using the generated code](#using-the-generated-code).
 
-> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) — you can import those directly without generating anything. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
+> **Tip:** For common EDIFACT D03A message types, prebuilt packages are published under the `ballerinax` organization (e.g. `ballerinax/edifact.d03a.supplychain`) and can be imported directly without generating any code. See the [`ballerina/edi` module](https://github.com/ballerina-platform/module-ballerina-edi#working-with-standard-edi-formats).
 
 ## Generate from an X12 schema
 
-X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so you start from the X12 schema (XSD) you are entitled to use and convert it.
+X12 is the EDI standard used across North America. X12 specifications are licensed from ASC X12, so the workflow starts from a licensed X12 schema (XSD) and converts it into a Ballerina EDI schema.
 
 **Step 1 — Convert the X12 schema into a Ballerina EDI schema:**
 
@@ -59,7 +59,7 @@ $ bal edi convertX12Schema -i input/850.xsd -o resources/850-schema.json
 $ bal edi codegen -i resources/850-schema.json -o modules/po/po.bal
 ```
 
-The result is the same shape as the EDIFACT flow: typed records and parser functions you can use right away.
+The result matches the EDIFACT flow: typed records and parser functions ready for use.
 
 ## Using the generated code
 
@@ -106,7 +106,7 @@ public function main() returns error? {
 
 ### Reading and writing EDI envelopes
 
-A real EDI file is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
+An EDI interchange is wrapped in an **envelope** — interchange and (for X12) functional-group headers and trailers around one or more transactions. When the schema comes from an X12 or EDIFACT spec, `codegen` also emits typed envelope wrappers and envelope-aware functions:
 
 - `<Name>Interchange`, `<Name>FunctionalGroup` (X12), and `<Name>Transaction` records that mirror the envelope hierarchy. Each `<Name>Transaction.body` is `<Name>|error`, so a malformed transaction body is captured rather than aborting the whole parse (fail-safe).
 - `headersFromEdiString` — extracts just the envelope headers (useful for routing).
@@ -169,11 +169,11 @@ public function main() returns error? {
 }
 ```
 
-Because trading partners often use variations of a standard format, you can also generate a partner-specific package from partner-specific schemas.
+Because trading partners often use variations of a standard format, a partner-specific package can be generated from partner-specific schemas.
 
 ### Running a generated package as a REST service
 
-A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — handy when EDI processing should be its own microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
+A generated package also includes a REST connector, so it can be built (`bal build`) and run (`bal run`) as a standalone service that converts EDI over HTTP — useful when EDI processing is deployed as a separate microservice. Each schema gets an EDI-to-JSON and a JSON-to-EDI endpoint. For example, converting an X12 850 to JSON:
 
 ```
 curl --location 'http://localhost:9090/porderParser/edis/850' \
@@ -189,7 +189,7 @@ The matching `objects/850` endpoint performs the reverse (JSON to X12 850 text).
 
 ## Custom EDI schemas
 
-If you work with a proprietary or non-standard format that is neither X12 nor EDIFACT, describe its structure directly in the Ballerina EDI schema format (JSON) and run `codegen` on it — no conversion step needed. A minimal schema for a simple order looks like:
+For a proprietary or non-standard format that is neither X12 nor EDIFACT, the structure can be described directly in the Ballerina EDI schema format (JSON) and passed to `codegen` without a conversion step. A minimal schema for a simple order looks like:
 
 ```json
 {


### PR DESCRIPTION
Gives the `editoolspackage` tool a proper Ballerina Central landing page and refreshes the repo README.

- Replace the placeholder `Module.md` / `Package.md` stubs with a user-facing `edi-tools-package/README.md` (the Central landing page), derived from the repo README's body.
- Add `readme = "README.md"` to the package template (`build-config/resources/package/Ballerina.toml`) so `updateTomlFiles` regenerates the package `Ballerina.toml` with the README wiring.
- Reorganize the repo `README.md` to lead with EDIFACT/X12 generation (the common case), then generated-code usage, library packaging, and finally custom/ESL schemas; tone aligned with the module docs.

Verified locally with `bal pack`. Docs-only; excludes the in-flight version-bump edits in the working tree.
