### PR TITLE
Populate schema envelope in X12 headers mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [Generate envelope-aware EDI schemas and typed envelope wrappers (BEP-1441)](https://github.com/ballerina-platform/ballerina-spec/issues/1441)
+- [Populate the schema envelope in X12 headers mode so `convertX12Schema -H` output works with envelope-aware APIs (BEP-1441)](https://github.com/ballerina-platform/ballerina-spec/issues/1441)
 
 ## [2.0.0] - 2024-05-29
 

--- a/edi-tools/modules/x12xsd/x12xsd.bal
+++ b/edi-tools/modules/x12xsd/x12xsd.bal
@@ -190,7 +190,95 @@ function convertFromX12WithHeaders(string inPath) returns edi:EdiSchema|error {
     }
     edi:EdiSegGroupSchema rootSegGroupSchema = check convertSegmentGroup(root, interchangeXsd, ediSchema, inPath);
     ediSchema.segments = rootSegGroupSchema.segments;
+    check populateX12EnvelopeFromHeaders(ediSchema);
     return ediSchema;
+}
+
+// Lifts the X12 envelope out of the nested `segments[]` produced by headers-mode
+// conversion into the structured `envelope` field required by envelope-aware
+// runtime APIs. Headers mode builds a fixed three-level nesting from the
+// supplied Interchange/FunctionalGroup XSDs:
+//   segments = [ISA, FunctionalGroup[GS, Transaction[ST, ...body..., SE], GE], IEA]
+// Unlike the plain path (`populateX12Envelope`), the user supplies their own
+// envelope segment definitions, so those are preserved as-is and only relocated.
+function populateX12EnvelopeFromHeaders(edi:EdiSchema schema) returns error? {
+    edi:EdiUnitSchema? isa = ();
+    edi:EdiUnitSchema? iea = ();
+    edi:EdiSegGroupSchema? functionalGroup = ();
+    foreach edi:EdiUnitSchema unit in schema.segments {
+        string? code = getRefCode(unit, schema);
+        if code == "ISA" {
+            isa = unit;
+        } else if code == "IEA" {
+            iea = unit;
+        } else if unit is edi:EdiSegGroupSchema {
+            functionalGroup = unit;
+        }
+    }
+    if isa is () || iea is () {
+        return error(string `Cannot generate envelope for ${schema.name}: interchange ` +
+                "control header (ISA) or trailer (IEA) not found in the schema.");
+    }
+    if functionalGroup is () {
+        return error(string `Cannot generate envelope for ${schema.name}: functional ` +
+                "group not found in the schema.");
+    }
+
+    edi:EdiUnitSchema? gs = ();
+    edi:EdiUnitSchema? ge = ();
+    edi:EdiSegGroupSchema? 'transaction = ();
+    foreach edi:EdiUnitSchema unit in functionalGroup.segments {
+        string? code = getRefCode(unit, schema);
+        if code == "GS" {
+            gs = unit;
+        } else if code == "GE" {
+            ge = unit;
+        } else if unit is edi:EdiSegGroupSchema {
+            'transaction = unit;
+        }
+    }
+    if gs is () || ge is () {
+        return error(string `Cannot generate envelope for ${schema.name}: functional ` +
+                "group header (GS) or trailer (GE) not found in the schema.");
+    }
+    if 'transaction is () {
+        return error(string `Cannot generate envelope for ${schema.name}: transaction ` +
+                "set not found within the functional group.");
+    }
+
+    edi:EdiUnitSchema? st = ();
+    edi:EdiUnitSchema? se = ();
+    edi:EdiUnitSchema[] body = [];
+    foreach edi:EdiUnitSchema unit in 'transaction.segments {
+        string? code = getRefCode(unit, schema);
+        if code == "ST" {
+            st = unit;
+        } else if code == "SE" {
+            se = unit;
+        } else {
+            body.push(unit);
+        }
+    }
+    if st is () || se is () {
+        return error(string `Cannot generate envelope for ${schema.name}: transaction set ` +
+                "header (ST) or trailer (SE) not found in the schema.");
+    }
+
+    schema.envelope = {
+        interchange: {
+            header: forceMandatoryX12([isa]),
+            trailer: forceMandatoryX12([iea])
+        },
+        group: {
+            header: forceMandatoryX12([gs]),
+            trailer: forceMandatoryX12([ge])
+        },
+        'transaction: {
+            header: forceMandatoryX12([st]),
+            trailer: forceMandatoryX12([se])
+        }
+    };
+    schema.segments = body;
 }
 
 function convertSegmentGroup(xml segmentGroup, xml x12xsd, edi:EdiSchema schema, string dirPath = "", int parentMinOccur = 0, int parentMaxOccur = 1) returns edi:EdiSegGroupSchema|error {

--- a/edi-tools/modules/x12xsd/x12xsd.bal
+++ b/edi-tools/modules/x12xsd/x12xsd.bal
@@ -202,67 +202,16 @@ function convertFromX12WithHeaders(string inPath) returns edi:EdiSchema|error {
 // Unlike the plain path (`populateX12Envelope`), the user supplies their own
 // envelope segment definitions, so those are preserved as-is and only relocated.
 function populateX12EnvelopeFromHeaders(edi:EdiSchema schema) returns error? {
-    edi:EdiUnitSchema? isa = ();
-    edi:EdiUnitSchema? iea = ();
-    edi:EdiSegGroupSchema? functionalGroup = ();
-    foreach edi:EdiUnitSchema unit in schema.segments {
-        string? code = getRefCode(unit, schema);
-        if code == "ISA" {
-            isa = unit;
-        } else if code == "IEA" {
-            iea = unit;
-        } else if unit is edi:EdiSegGroupSchema {
-            functionalGroup = unit;
-        }
-    }
-    if isa is () || iea is () {
-        return error(string `Cannot generate envelope for ${schema.name}: interchange ` +
-                "control header (ISA) or trailer (IEA) not found in the schema.");
-    }
-    if functionalGroup is () {
-        return error(string `Cannot generate envelope for ${schema.name}: functional ` +
-                "group not found in the schema.");
-    }
+    [edi:EdiUnitSchema, edi:EdiUnitSchema, edi:EdiUnitSchema[]] [isa, iea, interchangeBody] =
+            check extractEnvelopeHeaderTrailer(schema.segments, "ISA", "IEA", schema, "interchange");
+    edi:EdiSegGroupSchema functionalGroup = check singleEnvelopeGroup(interchangeBody, schema, "functional group");
 
-    edi:EdiUnitSchema? gs = ();
-    edi:EdiUnitSchema? ge = ();
-    edi:EdiSegGroupSchema? 'transaction = ();
-    foreach edi:EdiUnitSchema unit in functionalGroup.segments {
-        string? code = getRefCode(unit, schema);
-        if code == "GS" {
-            gs = unit;
-        } else if code == "GE" {
-            ge = unit;
-        } else if unit is edi:EdiSegGroupSchema {
-            'transaction = unit;
-        }
-    }
-    if gs is () || ge is () {
-        return error(string `Cannot generate envelope for ${schema.name}: functional ` +
-                "group header (GS) or trailer (GE) not found in the schema.");
-    }
-    if 'transaction is () {
-        return error(string `Cannot generate envelope for ${schema.name}: transaction ` +
-                "set not found within the functional group.");
-    }
+    [edi:EdiUnitSchema, edi:EdiUnitSchema, edi:EdiUnitSchema[]] [gs, ge, groupBody] =
+            check extractEnvelopeHeaderTrailer(functionalGroup.segments, "GS", "GE", schema, "functional group");
+    edi:EdiSegGroupSchema 'transaction = check singleEnvelopeGroup(groupBody, schema, "transaction set");
 
-    edi:EdiUnitSchema? st = ();
-    edi:EdiUnitSchema? se = ();
-    edi:EdiUnitSchema[] body = [];
-    foreach edi:EdiUnitSchema unit in 'transaction.segments {
-        string? code = getRefCode(unit, schema);
-        if code == "ST" {
-            st = unit;
-        } else if code == "SE" {
-            se = unit;
-        } else {
-            body.push(unit);
-        }
-    }
-    if st is () || se is () {
-        return error(string `Cannot generate envelope for ${schema.name}: transaction set ` +
-                "header (ST) or trailer (SE) not found in the schema.");
-    }
+    [edi:EdiUnitSchema, edi:EdiUnitSchema, edi:EdiUnitSchema[]] [st, se, body] =
+            check extractEnvelopeHeaderTrailer('transaction.segments, "ST", "SE", schema, "transaction set");
 
     schema.envelope = {
         interchange: {
@@ -279,6 +228,46 @@ function populateX12EnvelopeFromHeaders(edi:EdiSchema schema) returns error? {
         }
     };
     schema.segments = body;
+}
+
+// Scans one envelope level, returning its single header segment, single trailer
+// segment, and the remaining units. Fails fast if the header or trailer code
+// appears anything other than exactly once, so a malformed headers XSD produces
+// a deterministic error rather than a silently arbitrary envelope.
+function extractEnvelopeHeaderTrailer(edi:EdiUnitSchema[] units, string headerCode, string trailerCode,
+        edi:EdiSchema schema, string level)
+        returns [edi:EdiUnitSchema, edi:EdiUnitSchema, edi:EdiUnitSchema[]]|error {
+    edi:EdiUnitSchema[] headers = [];
+    edi:EdiUnitSchema[] trailers = [];
+    edi:EdiUnitSchema[] rest = [];
+    foreach edi:EdiUnitSchema unit in units {
+        string? code = getRefCode(unit, schema);
+        if code == headerCode {
+            headers.push(unit);
+        } else if code == trailerCode {
+            trailers.push(unit);
+        } else {
+            rest.push(unit);
+        }
+    }
+    if headers.length() != 1 || trailers.length() != 1 {
+        return error(string `Cannot generate envelope for ${schema.name}: expected exactly one ` +
+                string `${headerCode} and one ${trailerCode} at the ${level} level, but found ` +
+                string `${headers.length()} and ${trailers.length()}.`);
+    }
+    return [headers[0], trailers[0], rest];
+}
+
+// Returns the single nested segment group at an envelope level. Fails fast when
+// the level does not contain exactly one segment group, so an unexpected extra
+// group is reported rather than silently picked.
+function singleEnvelopeGroup(edi:EdiUnitSchema[] units, edi:EdiSchema schema, string level)
+        returns edi:EdiSegGroupSchema|error {
+    if units.length() != 1 || units[0] !is edi:EdiSegGroupSchema {
+        return error(string `Cannot generate envelope for ${schema.name}: expected exactly one ` +
+                string `${level} segment group, but found ${units.length()} unit(s).`);
+    }
+    return <edi:EdiSegGroupSchema>units[0];
 }
 
 function convertSegmentGroup(xml segmentGroup, xml x12xsd, edi:EdiSchema schema, string dirPath = "", int parentMinOccur = 0, int parentMaxOccur = 1) returns edi:EdiSegGroupSchema|error {

--- a/edi-tools/modules/x12xsd/x12xsd.bal
+++ b/edi-tools/modules/x12xsd/x12xsd.bal
@@ -200,7 +200,8 @@ function convertFromX12WithHeaders(string inPath) returns edi:EdiSchema|error {
 // supplied Interchange/FunctionalGroup XSDs:
 //   segments = [ISA, FunctionalGroup[GS, Transaction[ST, ...body..., SE], GE], IEA]
 // Unlike the plain path (`populateX12Envelope`), the user supplies their own
-// envelope segment definitions, so those are preserved as-is and only relocated.
+// envelope segment definitions; those definitions are preserved, relocated into
+// the envelope, and promoted to mandatory (minOccurances = 1) via `forceMandatoryX12`.
 function populateX12EnvelopeFromHeaders(edi:EdiSchema schema) returns error? {
     [edi:EdiUnitSchema, edi:EdiUnitSchema, edi:EdiUnitSchema[]] [isa, iea, interchangeBody] =
             check extractEnvelopeHeaderTrailer(schema.segments, "ISA", "IEA", schema, "interchange");
@@ -253,7 +254,7 @@ function extractEnvelopeHeaderTrailer(edi:EdiUnitSchema[] units, string headerCo
     if headers.length() != 1 || trailers.length() != 1 {
         return error(string `Cannot generate envelope for ${schema.name}: expected exactly one ` +
                 string `${headerCode} and one ${trailerCode} at the ${level} level, but found ` +
-                string `${headers.length()} and ${trailers.length()}.`);
+                string `${headers.length()} ${headerCode} and ${trailers.length()} ${trailerCode}.`);
     }
     return [headers[0], trailers[0], rest];
 }

--- a/edi-tools/tests/resources/x12xsd/headers/FunctionalGroup.xsd
+++ b/edi-tools/tests/resources/x12xsd/headers/FunctionalGroup.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:include schemaLocation="TestMessage.xsd"/>
+    <xs:element name="X12_FunctionalGroup">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="GS_FunctionalGroupHeader"/>
+                <xs:element ref="X12_004010_TEST" maxOccurs="unbounded"/>
+                <xs:element ref="GE_FunctionalGroupTrailer"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="GS_FunctionalGroupHeader">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="GS01__FunctionalIdentifierCode">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="GE_FunctionalGroupTrailer">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="GE01__NumberOfTransactionSetsIncluded">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/edi-tools/tests/resources/x12xsd/headers/Interchange.xsd
+++ b/edi-tools/tests/resources/x12xsd/headers/Interchange.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:include schemaLocation="FunctionalGroup.xsd"/>
+    <xs:element name="X12_Interchange">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="ISA_InterchangeControlHeader"/>
+                <xs:element ref="X12_FunctionalGroup" maxOccurs="unbounded"/>
+                <xs:element ref="IEA_InterchangeControlTrailer"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="ISA_InterchangeControlHeader">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="ISA01__AuthorizationInformationQualifier">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="IEA_InterchangeControlTrailer">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="IEA01__NumberOfIncludedFunctionalGroups">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/edi-tools/tests/resources/x12xsd/headers/TestMessage.xsd
+++ b/edi-tools/tests/resources/x12xsd/headers/TestMessage.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="X12_004010_TEST">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="ST_TransactionSetHeader"/>
+                <xs:element ref="BGN_BeginningSegment"/>
+                <xs:element ref="SE_TransactionSetTrailer"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="ST_TransactionSetHeader">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="ST01__TransactionSetIdentifierCode">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="BGN_BeginningSegment">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="BGN01__TransactionSetPurposeCode">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="SE_TransactionSetTrailer">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="SE01__NumberOfIncludedSegments">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/edi-tools/tests/x12xsd_conversion_test.bal
+++ b/edi-tools/tests/x12xsd_conversion_test.bal
@@ -39,8 +39,12 @@ function testX12XsdConversionWithHeaders() returns error? {
     }
     test:assertEquals(refCode(schema, envelope.interchange.header[0]), "ISA");
     test:assertEquals(refCode(schema, envelope.interchange.trailer[0]), "IEA");
-    test:assertEquals(refCode(schema, (<edi:EdiEnvelopeLevel>envelope.group).header[0]), "GS");
-    test:assertEquals(refCode(schema, (<edi:EdiEnvelopeLevel>envelope.group).trailer[0]), "GE");
+    edi:EdiEnvelopeLevel? group = envelope.group;
+    if group is () {
+        test:assertFail("Headers-mode envelope is missing the functional group level.");
+    }
+    test:assertEquals(refCode(schema, group.header[0]), "GS");
+    test:assertEquals(refCode(schema, group.trailer[0]), "GE");
     test:assertEquals(refCode(schema, envelope.'transaction.header[0]), "ST");
     test:assertEquals(refCode(schema, envelope.'transaction.trailer[0]), "SE");
 

--- a/edi-tools/tests/x12xsd_conversion_test.bal
+++ b/edi-tools/tests/x12xsd_conversion_test.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/edi;
+import ballerina/io;
 import ballerina/test;
 import editools.x12xsd;
 
@@ -22,4 +24,41 @@ function testX12XsdConversion() returns error? {
     string inpath = "tests/resources/x12xsd/004010/210.xsd";
     string outpath = "tests/resources/x12xsd/004010/210.json";
     check x12xsd:convertFromX12XsdAndWrite(inpath, outpath);
+}
+
+@test:Config
+function testX12XsdConversionWithHeaders() returns error? {
+    string inpath = "tests/resources/x12xsd/headers";
+    string outpath = "tests/resources/x12xsd/headers/schema.json";
+    check x12xsd:convertFromX12WithHeadersAndWrite(inpath, outpath);
+
+    edi:EdiSchema schema = check (check io:fileReadJson(outpath)).cloneWithType();
+    edi:EdiEnvelopeSchema? envelope = schema.envelope;
+    if envelope is () {
+        test:assertFail("Headers-mode conversion did not populate the envelope.");
+    }
+    test:assertEquals(refCode(schema, envelope.interchange.header[0]), "ISA");
+    test:assertEquals(refCode(schema, envelope.interchange.trailer[0]), "IEA");
+    test:assertEquals(refCode(schema, (<edi:EdiEnvelopeLevel>envelope.group).header[0]), "GS");
+    test:assertEquals(refCode(schema, (<edi:EdiEnvelopeLevel>envelope.group).trailer[0]), "GE");
+    test:assertEquals(refCode(schema, envelope.'transaction.header[0]), "ST");
+    test:assertEquals(refCode(schema, envelope.'transaction.trailer[0]), "SE");
+
+    // The envelope segments must be lifted out of the top-level body.
+    foreach edi:EdiUnitSchema unit in schema.segments {
+        string? code = refCode(schema, unit);
+        test:assertNotEquals(code, "ISA", "ISA should be lifted into the envelope.");
+        test:assertNotEquals(code, "ST", "ST should be lifted into the envelope.");
+    }
+}
+
+function refCode(edi:EdiSchema schema, edi:EdiUnitSchema unit) returns string? {
+    if unit is edi:EdiSegSchema {
+        return unit.code;
+    }
+    if unit is edi:EdiUnitRef {
+        edi:EdiSegSchema? def = schema.segmentDefinitions[unit.ref];
+        return def?.code;
+    }
+    return ();
 }


### PR DESCRIPTION
## Purpose

PR #80 (BEP-1441) added the structured `envelope` field and envelope-aware runtime APIs (`interchangeFromEdiString`, `headersFromEdiString`, `interchangeToEdiString`), which require that field. But envelope population was only wired into the **plain** `convertX12Schema` path (`convertFromX12Xsd`).

The **headers** path (`-H`, `convertFromX12WithHeaders`) still emitted the pre-existing shape: `ISA`/`GS`/`ST` left nested inline in `segments[]` with `envelope: null`. As a result, any schema generated with `-H` failed every envelope-aware API with `SchemaCompatibilityError: Schema '<name>' has no envelope defined`. (`-c` alone was fine as it loops the plain path; only `-c -H` inherited the gap.)

This is X12-only — EDIFACT's single conversion path always populates the envelope.

## Changes

- Add `populateX12EnvelopeFromHeaders`, invoked at the end of `convertFromX12WithHeaders`. It lifts the fixed three-level nesting (`ISA` / `FunctionalGroup[GS, Transaction[ST, …body…, SE], GE]` / `IEA`) into the structured `envelope` and leaves only the transaction body in `segments[]`.
- Reuses existing `getRefCode` and `forceMandatoryX12` helpers.
- Unlike the plain path (which injects predefined ISA/GS/… definitions for a bare transaction-set XSD), the headers path **preserves the user-supplied envelope segment definitions** and only relocates + promotes them — keeping headers mode meaningful.

## Testing

- New `testX12XsdConversionWithHeaders` using a minimal hand-authored X12 interchange XSD trio (Interchange → FunctionalGroup → message) asserting the envelope is populated with ISA/IEA, GS/GE, ST/SE and that ISA/ST are lifted out of the body. Existing plain-path test still passes (`2 passing, 0 failing`).

## Related

- Runtime "no envelope defined" error message is being clarified separately in `ballerina/edi`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated X12 schema conversion in headers mode to populate the structured `envelope` (ISA/IEA, GS/GE, ST/SE) instead of leaving those fixed header/trailer segments nested only under `segments[]`. This aligns `convertX12Schema -H` output with envelope-aware runtime APIs and ensures user-defined envelope segment definitions are preserved. The change also adds stricter extraction/validation for the expected header/trailer structure and promotes the extracted envelope segments to mandatory entries. A new test (`testX12XsdConversionWithHeaders`) and accompanying XSD fixtures verify correct envelope generation and confirm that lifted ISA/ST units are not retained in the top-level `segments`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->