### PR TITLE
Surface EDI command failures instead of exiting successfully

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [Retain segment fields whose names wrap across two lines in the EDIFACT specification, which were previously dropped from the generated segment definitions](https://github.com/ballerina-platform/ballerina-library/issues/8983)
 - [Surface command failures instead of exiting with a success status: print usage for `--help` and for missing options, propagate the EDI tool exit code, and stop discarding the tool's error output](https://github.com/ballerina-platform/ballerina-library/issues/8982)
+- [Skip non-`.json` entries in a `libgen` schema folder with a warning instead of failing on them, and remove the generated package when no schemas could be generated so an unbuildable one is never left behind](https://github.com/ballerina-platform/ballerina-library/issues/8982)
 
 ## [2.0.0] - 2024-05-29
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [Retain segment fields whose names wrap across two lines in the EDIFACT specification, which were previously dropped from the generated segment definitions](https://github.com/ballerina-platform/ballerina-library/issues/8983)
+- [Surface command failures instead of exiting with a success status: print usage for missing options, propagate the EDI tool exit code, and stop discarding the tool's error output](https://github.com/ballerina-platform/ballerina-library/issues/8982)
 
 ## [2.0.0] - 2024-05-29
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [Retain segment fields whose names wrap across two lines in the EDIFACT specification, which were previously dropped from the generated segment definitions](https://github.com/ballerina-platform/ballerina-library/issues/8983)
-- [Surface command failures instead of exiting with a success status: print usage for missing options, propagate the EDI tool exit code, and stop discarding the tool's error output](https://github.com/ballerina-platform/ballerina-library/issues/8982)
+- [Surface command failures instead of exiting with a success status: print usage for `--help` and for missing options, propagate the EDI tool exit code, and stop discarding the tool's error output](https://github.com/ballerina-platform/ballerina-library/issues/8982)
 
 ## [2.0.0] - 2024-05-29
 

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
@@ -21,27 +21,20 @@ package io.ballerina.edi.cmd;
 import io.ballerina.cli.BLauncherCmd;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.List;
 
 @CommandLine.Command(name = "codegen", description = "Generates Ballerina records and parser functions for a given EDI schema.")
 public class CodegenCmd implements BLauncherCmd {
-    private static final String EDI_TOOL = "editools.jar";
     private static final String CMD_NAME = "codegen";
+    private static final String HELP_FILE = CMD_NAME + ".help";
 
     private final PrintStream printStream;
 
-    @CommandLine.Option(names = { "-i", "--input" }, description = "EDI schema file path")
+    @CommandLine.Option(names = { "-i", "--input" }, required = true, description = "EDI schema file path")
     private String schemaPath;
 
-    @CommandLine.Option(names = { "-o", "--output" }, description = "Output path")
+    @CommandLine.Option(names = { "-o", "--output" }, required = true, description = "Output path")
     private String outputPath;
 
     public CodegenCmd() {
@@ -51,32 +44,10 @@ public class CodegenCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (schemaPath == null || outputPath == null) {
-            StringBuilder stringBuilder = new StringBuilder();
-            printUsage(stringBuilder);
-            printStream.println(stringBuilder.toString());
-            return;
+            throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }
-        try {
-            printStream.println("Generating code for " + schemaPath + "...");
-            Class<?> clazz = CodegenCmd.class;
-            ClassLoader classLoader = clazz.getClassLoader();
-            Path tempFile = Files.createTempFile(null, ".jar");
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder(
-                    "bal", "run", tempFile.toAbsolutePath().toString(), "--", "codegen", schemaPath, outputPath);
-            processBuilder.inheritIO();
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte b[] = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
-        } catch (Exception e) {
-            printStream.println("Error in generating code. " + e.getMessage());
-            e.printStackTrace();
-        }
+        printStream.println("Generating code for " + schemaPath + "...");
+        EdiCmdUtils.runEdiTool(List.of(CMD_NAME, schemaPath, outputPath));
     }
 
     @Override
@@ -86,25 +57,12 @@ public class CodegenCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/codegen.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/CodegenCmd.java
@@ -31,6 +31,9 @@ public class CodegenCmd implements BLauncherCmd {
 
     private final PrintStream printStream;
 
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
+    private boolean helpFlag;
+
     @CommandLine.Option(names = { "-i", "--input" }, required = true, description = "EDI schema file path")
     private String schemaPath;
 
@@ -43,6 +46,10 @@ public class CodegenCmd implements BLauncherCmd {
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         if (schemaPath == null || outputPath == null) {
             throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertEdifactCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertEdifactCmd.java
@@ -42,6 +42,9 @@ public class ConvertEdifactCmd implements BLauncherCmd {
 
     private final PrintStream printStream;
 
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
+    private boolean helpFlag;
+
     @CommandLine.Option(names = { "-v", "--version" }, required = true, description = "EDIFACT version")
     private String version;
 
@@ -62,6 +65,10 @@ public class ConvertEdifactCmd implements BLauncherCmd {
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         if (version == null || dir == null) {
             throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertEdifactCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertEdifactCmd.java
@@ -19,15 +19,11 @@
 package io.ballerina.edi.cmd;
 
 import io.ballerina.cli.BLauncherCmd;
+import io.ballerina.cli.launcher.LauncherUtils;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -42,15 +38,18 @@ import java.util.zip.ZipInputStream;
 @CommandLine.Command(name = "convertEdifactSchema", description = "Converts EDIFACT schema to EDI schema.")
 public class ConvertEdifactCmd implements BLauncherCmd {
     private static final String CMD_NAME = "convertEdifactSchema";
+    private static final String HELP_FILE = "convertEDIfact.help";
+
     private final PrintStream printStream;
 
-    @CommandLine.Option(names = { "-v", "--version" }, description = "EDIFACT version")
+    @CommandLine.Option(names = { "-v", "--version" }, required = true, description = "EDIFACT version")
     private String version;
 
     @CommandLine.Option(names = { "-t", "--type" }, description = "EDIFACT message type")
     private String type;
 
-    @CommandLine.Option(names = { "-o", "--output" }, description = "EDIFACT schema directory path")
+    @CommandLine.Option(names = { "-o", "--output" }, required = true,
+            description = "EDIFACT schema directory path")
     private String dir;
 
     @CommandLine.Option(names = { "-i", "--input" },
@@ -64,23 +63,20 @@ public class ConvertEdifactCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (version == null || dir == null) {
-            StringBuilder stringBuilder = new StringBuilder();
-            printUsage(stringBuilder);
-            printStream.println(stringBuilder.toString());
-            return;
+            throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }
-        Path toolJar = null;
+        printStream.println("Generating EDI schema for EDIFACT schema ...");
+        // A blank --input is treated as not supplied, so the conversion reports
+        // where to download the directory instead of scanning the current directory.
+        String inputPath = input == null ? "" : input.trim();
         Path extractedInput = null;
         try {
-            printStream.println("Generating EDI schema for EDIFACT schema ...");
-            // A blank --input is treated as not supplied, so the conversion reports
-            // where to download the directory instead of scanning the current directory.
-            String inputPath = input == null ? "" : input.trim();
             String inputDir = "";
             if (!inputPath.isEmpty()) {
                 Path source = Path.of(inputPath);
                 if (!Files.exists(source)) {
-                    throw new IOException("EDIFACT directory input '" + inputPath + "' does not exist.");
+                    throw LauncherUtils.createLauncherException(
+                            "EDIFACT directory input '" + inputPath + "' does not exist.");
                 }
                 if (Files.isDirectory(source)) {
                     inputDir = source.toAbsolutePath().toString();
@@ -90,38 +86,12 @@ public class ConvertEdifactCmd implements BLauncherCmd {
                     inputDir = extractedInput.toString();
                 }
             }
-            URL res = ConvertEdifactCmd.class.getClassLoader().getResource("editools.jar");
-            toolJar = Files.createTempFile(null, ".jar");
-            try (InputStream in = res.openStream()) {
-                Files.copy(in, toolJar, StandardCopyOption.REPLACE_EXISTING);
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder(
-                    "bal", "run", toolJar.toAbsolutePath().toString(), "--", CMD_NAME, version, type == null ? "" : type,
-                    dir, inputDir);
-            processBuilder.inheritIO();
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte b[] = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
-        } catch (Exception e) {
-            printStream.println("Error in generating edi schema for edifact schema. " + e.getMessage());
-            e.printStackTrace();
-        } finally {
-            delete(toolJar);
-            deleteRecursively(extractedInput);
-        }
-    }
-
-    private void delete(Path file) {
-        if (file == null) {
-            return;
-        }
-        try {
-            Files.deleteIfExists(file);
+            EdiCmdUtils.runEdiTool(List.of(CMD_NAME, version, type == null ? "" : type, dir, inputDir));
         } catch (IOException e) {
-            printStream.println("Warning: could not delete " + file + ". " + e.getMessage());
+            throw LauncherUtils.createLauncherException(
+                    "failed to read the EDIFACT directory input '" + inputPath + "': " + e.getMessage());
+        } finally {
+            deleteRecursively(extractedInput);
         }
     }
 
@@ -183,25 +153,12 @@ public class ConvertEdifactCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/convertEDIfact.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertX12Cmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertX12Cmd.java
@@ -33,6 +33,9 @@ public class ConvertX12Cmd implements BLauncherCmd {
 
     private final PrintStream printStream;
 
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
+    private boolean helpFlag;
+
     @CommandLine.Option(names = { "-H", "--headers" }, description = { "Include headers in the input" })
     private boolean headersIncluded;
 
@@ -54,6 +57,10 @@ public class ConvertX12Cmd implements BLauncherCmd {
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         if (inputPath == null || outputPath == null) {
             throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertX12Cmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/ConvertX12Cmd.java
@@ -21,15 +21,7 @@ package io.ballerina.edi.cmd;
 import io.ballerina.cli.BLauncherCmd;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +29,7 @@ import java.util.List;
 public class ConvertX12Cmd implements BLauncherCmd {
 
     private static final String CMD_NAME = "convertX12Schema";
-    private static final String EDI_TOOL = "editools.jar";
+    private static final String HELP_FILE = "convertX12.help";
 
     private final PrintStream printStream;
 
@@ -47,10 +39,10 @@ public class ConvertX12Cmd implements BLauncherCmd {
     @CommandLine.Option(names = { "-c", "--collection" }, description = { "Switch to collection mode" })
     private boolean collectionMode;
 
-    @CommandLine.Option(names = { "-i", "--input" }, description = { "Input X12 schema path" })
+    @CommandLine.Option(names = { "-i", "--input" }, required = true, description = { "Input X12 schema path" })
     private String inputPath;
 
-    @CommandLine.Option(names = { "-o", "--output" }, description = { "Output path" })
+    @CommandLine.Option(names = { "-o", "--output" }, required = true, description = { "Output path" })
     private String outputPath;
 
     @CommandLine.Option(names = { "-d", "--segdet" }, description = { "Segment details path" })
@@ -63,56 +55,32 @@ public class ConvertX12Cmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (inputPath == null || outputPath == null) {
-            StringBuilder stringBuilder = new StringBuilder();
-            printUsage(stringBuilder);
-            printStream.println(stringBuilder.toString());
-            return;
+            throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }
-        StringBuilder stringBuilder = new StringBuilder("Converting schema ");
+        StringBuilder progress = new StringBuilder("Converting schema ");
         if (collectionMode) {
-            stringBuilder.append("in collection ");
+            progress.append("in collection ");
         }
         if (headersIncluded) {
-            stringBuilder.append("with headers ");
+            progress.append("with headers ");
         }
-        stringBuilder.append(inputPath).append("...");
-        printStream.println(stringBuilder);
-        Class<?> clazz = ConvertX12Cmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        try {
-            Path tempFile = Files.createTempFile(null, ".jar");
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            List<String> argsList = new ArrayList<>();
-            argsList.add("bal");
-            argsList.add("run");
-            argsList.add(tempFile.toAbsolutePath().toString());
-            argsList.add("--");
-            argsList.add(CMD_NAME);
-            if (headersIncluded) {
-                argsList.add("H");
-            }
-            if (collectionMode) {
-                argsList.add("c");
-            }
-            argsList.add(inputPath);
-            argsList.add(outputPath);
-            if (segdetPath != null) {
-                argsList.add(segdetPath);
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder(argsList);
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte[] b = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
+        progress.append(inputPath).append("...");
+        printStream.println(progress);
 
-        } catch (IOException | InterruptedException e) {
-            printStream.println("Error in generating code. " + e.getMessage());
-            e.printStackTrace();
+        List<String> toolArgs = new ArrayList<>();
+        toolArgs.add(CMD_NAME);
+        if (headersIncluded) {
+            toolArgs.add("H");
         }
+        if (collectionMode) {
+            toolArgs.add("c");
+        }
+        toolArgs.add(inputPath);
+        toolArgs.add(outputPath);
+        if (segdetPath != null) {
+            toolArgs.add(segdetPath);
+        }
+        EdiCmdUtils.runEdiTool(toolArgs);
     }
 
     @Override
@@ -122,25 +90,12 @@ public class ConvertX12Cmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/convertX12.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmd.java
@@ -21,6 +21,7 @@ package io.ballerina.edi.cmd;
 import io.ballerina.cli.BLauncherCmd;
 import picocli.CommandLine;
 
+import java.io.PrintStream;
 import java.util.List;
 
 /**
@@ -37,14 +38,21 @@ public class EdiCmd implements BLauncherCmd {
     private static final String CMD_NAME = "edi";
     private static final String HELP_FILE = "edi.help";
 
-    @CommandLine.Option(names = { "-h", "--help" }, hidden = true)
+    private final PrintStream printStream;
+
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
     private boolean helpFlag;
 
     public EdiCmd() {
+        this.printStream = System.out;
     }
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         EdiCmdUtils.runEdiTool(List.of());
     }
 

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmd.java
@@ -21,15 +21,7 @@ package io.ballerina.edi.cmd;
 import io.ballerina.cli.BLauncherCmd;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.List;
 
 /**
  * Main class to implement "edi" command for ballerina.
@@ -43,37 +35,17 @@ import java.nio.file.StandardCopyOption;
 })
 public class EdiCmd implements BLauncherCmd {
     private static final String CMD_NAME = "edi";
-    private static final String EDI_TOOL = "editools.jar";
-    private PrintStream printStream;
+    private static final String HELP_FILE = "edi.help";
 
     @CommandLine.Option(names = { "-h", "--help" }, hidden = true)
     private boolean helpFlag;
 
     public EdiCmd() {
-        printStream = System.out;
     }
 
     @Override
     public void execute() {
-        try {
-            Class<?> clazz = EdiCmd.class;
-            ClassLoader classLoader = clazz.getClassLoader();
-            Path tempFile = Files.createTempFile(null, ".jar");
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder("bal", "run", tempFile.toAbsolutePath().toString());
-            processBuilder.inheritIO();
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte b[] = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
-        } catch (Exception e) {
-            printStream.println("Error in executing EDI CLI commands. " + e.getMessage());
-            e.printStackTrace();
-        }
+        EdiCmdUtils.runEdiTool(List.of());
     }
 
     @Override
@@ -83,25 +55,12 @@ public class EdiCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/edi.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
@@ -113,6 +113,7 @@ final class EdiCmdUtils {
      */
     static void runEdiTool(List<String> toolArgs) {
         Path toolJar = null;
+        Process process = null;
         try {
             toolJar = extractEdiTool();
             List<String> command = new ArrayList<>(List.of("bal", "run", toolJar.toAbsolutePath().toString()));
@@ -120,7 +121,7 @@ final class EdiCmdUtils {
                 command.add("--");
                 command.addAll(toolArgs);
             }
-            Process process = new ProcessBuilder(command).inheritIO().start();
+            process = new ProcessBuilder(command).inheritIO().start();
             int exitCode = process.waitFor();
             if (exitCode != 0) {
                 throw LauncherUtils.createLauncherException(
@@ -130,6 +131,10 @@ final class EdiCmdUtils {
             throw LauncherUtils.createLauncherException("failed to run the EDI tool: " + e.getMessage());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            // The child is still running, and the jar it is executing is deleted below.
+            if (process != null) {
+                process.destroy();
+            }
             throw LauncherUtils.createLauncherException("the EDI tool was interrupted: " + e.getMessage());
         } finally {
             if (toolJar != null) {

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.edi.cmd;
+
+import io.ballerina.cli.launcher.BLauncherException;
+import io.ballerina.cli.launcher.LauncherUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared helpers for the {@code bal edi} commands: loading CLI help text and running the
+ * bundled EDI tool as a child process.
+ */
+final class EdiCmdUtils {
+
+    private static final String EDI_TOOL = "editools.jar";
+    private static final String CLI_DOCS = "cli-docs/";
+    private static final String HELP_NOT_AVAILABLE = "Helper text is not available.";
+
+    private EdiCmdUtils() {
+    }
+
+    /**
+     * Appends the contents of the given {@code cli-docs} help file to the given builder.
+     *
+     * @param stringBuilder builder to append the help text to
+     * @param helpFileName  help file name within {@code cli-docs}, e.g. {@code libgen.help}
+     */
+    static void appendHelp(StringBuilder stringBuilder, String helpFileName) {
+        ClassLoader classLoader = EdiCmdUtils.class.getClassLoader();
+        try (InputStream inputStream = classLoader.getResourceAsStream(CLI_DOCS + helpFileName)) {
+            if (inputStream == null) {
+                stringBuilder.append(HELP_NOT_AVAILABLE);
+                return;
+            }
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+                String line = reader.readLine();
+                if (line == null) {
+                    stringBuilder.append(HELP_NOT_AVAILABLE);
+                    return;
+                }
+                stringBuilder.append(line);
+                while ((line = reader.readLine()) != null) {
+                    stringBuilder.append('\n').append(line);
+                }
+            }
+        } catch (IOException e) {
+            stringBuilder.append(HELP_NOT_AVAILABLE);
+        }
+    }
+
+    /**
+     * Reports missing mandatory options by printing the command usage and failing the command.
+     * Reached only when a command is invoked programmatically, since picocli rejects missing
+     * required options before {@code execute()} runs.
+     *
+     * @param command      command name, e.g. {@code libgen}
+     * @param helpFileName help file name within {@code cli-docs}, e.g. {@code libgen.help}
+     * @return the exception to throw
+     */
+    static BLauncherException missingOptions(String command, String helpFileName) {
+        StringBuilder stringBuilder = new StringBuilder();
+        appendHelp(stringBuilder, helpFileName);
+        return LauncherUtils.createLauncherException(
+                "missing mandatory options for the 'edi " + command + "' command." + System.lineSeparator()
+                        + System.lineSeparator() + stringBuilder);
+    }
+
+    /**
+     * Runs the bundled EDI tool with the given arguments, streaming its output to the terminal.
+     * Fails the command if the tool cannot be started or exits with a non-zero status.
+     *
+     * @param toolArgs arguments passed to the EDI tool, the first being the mode
+     */
+    static void runEdiTool(List<String> toolArgs) {
+        Path toolJar = null;
+        try {
+            toolJar = extractEdiTool();
+            List<String> command = new ArrayList<>(List.of("bal", "run", toolJar.toAbsolutePath().toString()));
+            if (!toolArgs.isEmpty()) {
+                command.add("--");
+                command.addAll(toolArgs);
+            }
+            Process process = new ProcessBuilder(command).inheritIO().start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw LauncherUtils.createLauncherException(
+                        "the EDI tool failed with exit code " + exitCode + ".");
+            }
+        } catch (IOException e) {
+            throw LauncherUtils.createLauncherException("failed to run the EDI tool: " + e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw LauncherUtils.createLauncherException("the EDI tool was interrupted: " + e.getMessage());
+        } finally {
+            if (toolJar != null) {
+                try {
+                    Files.deleteIfExists(toolJar);
+                } catch (IOException e) {
+                    // The jar is also registered for deletion on exit, so a failure here is not fatal.
+                }
+            }
+        }
+    }
+
+    private static Path extractEdiTool() throws IOException {
+        Path tempFile = Files.createTempFile(null, ".jar");
+        tempFile.toFile().deleteOnExit();
+        try (InputStream in = EdiCmdUtils.class.getClassLoader().getResourceAsStream(EDI_TOOL)) {
+            if (in == null) {
+                throw LauncherUtils.createLauncherException(
+                        "the bundled EDI tool (" + EDI_TOOL + ") could not be found.");
+            }
+            Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return tempFile;
+    }
+}

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EdiCmdUtils.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -73,6 +74,18 @@ final class EdiCmdUtils {
         } catch (IOException e) {
             stringBuilder.append(HELP_NOT_AVAILABLE);
         }
+    }
+
+    /**
+     * Prints the help text of a command, used when the command is invoked with {@code --help}.
+     *
+     * @param printStream  stream to print the help text to
+     * @param helpFileName help file name within {@code cli-docs}, e.g. {@code libgen.help}
+     */
+    static void printHelp(PrintStream printStream, String helpFileName) {
+        StringBuilder stringBuilder = new StringBuilder();
+        appendHelp(stringBuilder, helpFileName);
+        printStream.println(stringBuilder);
     }
 
     /**

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EslCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EslCmd.java
@@ -21,30 +21,23 @@ package io.ballerina.edi.cmd;
 import io.ballerina.cli.BLauncherCmd;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.List;
 
 @CommandLine.Command(name = "convertESL", description = "Converts ESL schemas to Ballerina compatible JSON schemas.")
 public class EslCmd implements BLauncherCmd {
     private static final String CMD_NAME = "convertESL";
-    private static final String EDI_TOOL = "editools.jar";
+    private static final String HELP_FILE = "convertESL.help";
 
     private PrintStream printStream;
 
-    @CommandLine.Option(names = { "-b", "--basedef" }, description = "Segment definitions path")
+    @CommandLine.Option(names = { "-b", "--basedef" }, required = true, description = "Segment definitions path")
     private String basedefPath;
 
-    @CommandLine.Option(names = { "-i", "--input" }, description = "Input ESL schema path")
+    @CommandLine.Option(names = { "-i", "--input" }, required = true, description = "Input ESL schema path")
     private String schemaPath;
 
-    @CommandLine.Option(names = { "-o", "--output" }, description = "Output path")
+    @CommandLine.Option(names = { "-o", "--output" }, required = true, description = "Output path")
     private String outputPath;
 
     public EslCmd() {
@@ -54,32 +47,10 @@ public class EslCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (basedefPath == null || schemaPath == null || outputPath == null) {
-            StringBuilder stringBuilder = new StringBuilder();
-            printUsage(stringBuilder);
-            printStream.println(stringBuilder.toString());
-            return;
+            throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }
-        try {
-            printStream.println("Converting ESL schemas in " + schemaPath);
-            Class<?> clazz = LibgenCmd.class;
-            ClassLoader classLoader = clazz.getClassLoader();
-            Path tempFile = Files.createTempFile(null, ".jar");
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            ProcessBuilder processBuilder = new ProcessBuilder(
-                    "bal", "run", tempFile.toAbsolutePath().toString(), "--", "convertESL", schemaPath, basedefPath,
-                    outputPath);
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte b[] = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
-        } catch (Exception e) {
-            printStream.println("Error in generating library. " + e.getMessage());
-            e.printStackTrace();
-        }
+        printStream.println("Converting ESL schemas in " + schemaPath);
+        EdiCmdUtils.runEdiTool(List.of(CMD_NAME, schemaPath, basedefPath, outputPath));
     }
 
     @Override
@@ -89,25 +60,12 @@ public class EslCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/convertESL.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EslCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/EslCmd.java
@@ -31,6 +31,9 @@ public class EslCmd implements BLauncherCmd {
 
     private PrintStream printStream;
 
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
+    private boolean helpFlag;
+
     @CommandLine.Option(names = { "-b", "--basedef" }, required = true, description = "Segment definitions path")
     private String basedefPath;
 
@@ -46,6 +49,10 @@ public class EslCmd implements BLauncherCmd {
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         if (basedefPath == null || schemaPath == null || outputPath == null) {
             throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
@@ -19,32 +19,27 @@
 package io.ballerina.edi.cmd;
 
 import io.ballerina.cli.BLauncherCmd;
+import io.ballerina.cli.launcher.LauncherUtils;
 import picocli.CommandLine;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.List;
 
 @CommandLine.Command(name = "libgen", description = "Generates Ballerina package for code for the given collection of EDI schemas.")
 public class LibgenCmd implements BLauncherCmd {
     private static final String CMD_NAME = "libgen";
-    private static final String EDI_TOOL = "editools.jar";
+    private static final String HELP_FILE = CMD_NAME + ".help";
 
     private PrintStream printStream;
 
-    @CommandLine.Option(names = { "-p", "--package" }, description = "Package name(organization-name/package-name)")
+    @CommandLine.Option(names = { "-p", "--package" }, required = true,
+            description = "Package name(organization-name/package-name)")
     private String packageName;
 
-    @CommandLine.Option(names = { "-i", "--input" }, description = "EDI schemas path")
+    @CommandLine.Option(names = { "-i", "--input" }, required = true, description = "EDI schemas path")
     private String schemaPath;
 
-    @CommandLine.Option(names = { "-o", "--output" }, description = "Output path")
+    @CommandLine.Option(names = { "-o", "--output" }, required = true, description = "Output path")
     private String outputPath;
 
     public LibgenCmd() {
@@ -54,42 +49,18 @@ public class LibgenCmd implements BLauncherCmd {
     @Override
     public void execute() {
         if (packageName == null || schemaPath == null || outputPath == null) {
-            StringBuilder stringBuilder = new StringBuilder();
-            printUsage(stringBuilder);
-            printStream.println(stringBuilder.toString());
-            return;
+            throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }
         if (!packageName.matches("^[a-zA-Z0-9_]{1,256}/[a-zA-Z0-9_.]{1,256}$")) {
-            printStream.println(
-                    "Invalid package name. Package name should be in the format orgname/packagename."+
-                    " The orgname part must contain only alphanumeric characters or underscores and be 1 to 256 characters long."+
+            throw LauncherUtils.createLauncherException(
+                    "invalid package name. Package name should be in the format orgname/packagename." +
+                    " The orgname part must contain only alphanumeric characters or underscores and be 1 to 256 characters long." +
                     " The packagename part must contain only alphanumeric characters, underscores, or periods and be 1 to 256 characters long.");
-            return;
         }
-        try {
-            printStream.println("Generating library package for " + packageName + " : " + schemaPath);
-            Class<?> clazz = LibgenCmd.class;
-            ClassLoader classLoader = clazz.getClassLoader();
-            Path tempFile = Files.createTempFile(null, ".jar");
-            try (InputStream in = classLoader.getResourceAsStream(EDI_TOOL)) {
-                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-            }
-            String orgName = packageName.split("/")[0];
-            String libName = packageName.split("/")[1];
-            ProcessBuilder processBuilder = new ProcessBuilder(
-                    "bal", "run", tempFile.toAbsolutePath().toString(), "--", "libgen", orgName, libName, schemaPath,
-                    outputPath);
-            processBuilder.inheritIO();
-            Process process = processBuilder.start();
-            process.waitFor();
-            java.io.InputStream is = process.getInputStream();
-            byte b[] = new byte[is.available()];
-            is.read(b, 0, b.length);
-            printStream.println(new String(b));
-        } catch (Exception e) {
-            printStream.println("Error in generating library. " + e.getMessage());
-            e.printStackTrace();
-        }
+        printStream.println("Generating library package for " + packageName + " : " + schemaPath);
+        String orgName = packageName.split("/")[0];
+        String libName = packageName.split("/")[1];
+        EdiCmdUtils.runEdiTool(List.of(CMD_NAME, orgName, libName, schemaPath, outputPath));
     }
 
     @Override
@@ -99,25 +70,12 @@ public class LibgenCmd implements BLauncherCmd {
 
     @Override
     public void printLongDesc(StringBuilder stringBuilder) {
-        Class<?> clazz = EdiCmd.class;
-        ClassLoader classLoader = clazz.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("cli-docs/libgen.help");
-        if (inputStream != null) {
-            try (InputStreamReader inputStreamREader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                    BufferedReader br = new BufferedReader(inputStreamREader)) {
-                String content = br.readLine();
-                printStream.append(content);
-                while ((content = br.readLine()) != null) {
-                    printStream.append('\n').append(content);
-                }
-            } catch (IOException e) {
-                printStream.println("Helper text is not available.");
-            }
-        }
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override
     public void printUsage(StringBuilder stringBuilder) {
+        EdiCmdUtils.appendHelp(stringBuilder, HELP_FILE);
     }
 
     @Override

--- a/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
+++ b/edi-tools-cli/src/main/java/io/ballerina/edi/cmd/LibgenCmd.java
@@ -32,6 +32,9 @@ public class LibgenCmd implements BLauncherCmd {
 
     private PrintStream printStream;
 
+    @CommandLine.Option(names = { "-h", "--help" }, hidden = true, usageHelp = true)
+    private boolean helpFlag;
+
     @CommandLine.Option(names = { "-p", "--package" }, required = true,
             description = "Package name(organization-name/package-name)")
     private String packageName;
@@ -48,6 +51,10 @@ public class LibgenCmd implements BLauncherCmd {
 
     @Override
     public void execute() {
+        if (helpFlag) {
+            EdiCmdUtils.printHelp(printStream, HELP_FILE);
+            return;
+        }
         if (packageName == null || schemaPath == null || outputPath == null) {
             throw EdiCmdUtils.missingOptions(CMD_NAME, HELP_FILE);
         }

--- a/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/EdiCmdTest.java
+++ b/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/EdiCmdTest.java
@@ -21,11 +21,9 @@ package io.ballerina.edi.cmd;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -45,17 +43,7 @@ class EdiCmdTest {
 
     @Test
     void testNoArgumentInvocationRunsEdiTool() {
-        PrintStream originalOut = System.out;
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(captured));
-        try {
-            // EdiCmd picks up System.out in its constructor; the command swallows failures,
-            // so the error message on the captured stream is the only failure signal
-            new EdiCmd().execute();
-        } finally {
-            System.setOut(originalOut);
-        }
-        assertFalse(captured.toString().contains("Error in executing EDI CLI commands"),
-                "EDI tool invocation failed: " + captured);
+        // A failed tool run now fails the command, so completing without an exception is the assertion
+        assertDoesNotThrow(() -> new EdiCmd().execute());
     }
 }

--- a/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/ErrorReportingTest.java
+++ b/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/ErrorReportingTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import picocli.CommandLine;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -76,6 +79,32 @@ class ErrorReportingTest {
 
         assertFalse(stringBuilder.toString().isBlank(),
                 "printLongDesc appended nothing to the builder for '" + name + "'");
+    }
+
+    /**
+     * {@code --help} must print the help text rather than complaining about the mandatory options
+     * it was asking about. Declaring the options {@code required} without a {@code usageHelp}
+     * option would make picocli reject the invocation before the command runs.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("commands")
+    void testHelpFlagPrintsHelpInsteadOfRequiringOptions(String name, Supplier<BLauncherCmd> factory) {
+        PrintStream original = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            // The commands capture System.out in their constructors
+            BLauncherCmd cmd = factory.get();
+            CommandLine.ParseResult parsed = new CommandLine(cmd).parseArgs("--help");
+            assertTrue(parsed.isUsageHelpRequested(), "'--help' was not treated as a help request for " + name);
+            cmd.execute();
+        } finally {
+            System.setOut(original);
+        }
+        String help = captured.toString(StandardCharsets.UTF_8);
+        assertTrue(help.contains("bal edi"), "'--help' printed no usage for '" + name + "': " + help);
+        assertFalse(help.contains("Helper text is not available."),
+                "Help resource missing for '" + name + "'");
     }
 
     /**

--- a/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/ErrorReportingTest.java
+++ b/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/ErrorReportingTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.edi.cmd;
+
+import io.ballerina.cli.BLauncherCmd;
+import io.ballerina.cli.launcher.BLauncherException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import picocli.CommandLine;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that command failures are reported rather than silently swallowed: usage text is
+ * produced, missing mandatory options are rejected, and a failing EDI tool run fails the command.
+ */
+class ErrorReportingTest {
+
+    private static Stream<Arguments> commands() {
+        return Stream.of(
+                Arguments.of("codegen", (Supplier<BLauncherCmd>) CodegenCmd::new),
+                Arguments.of("libgen", (Supplier<BLauncherCmd>) LibgenCmd::new),
+                Arguments.of("convertESL", (Supplier<BLauncherCmd>) EslCmd::new),
+                Arguments.of(
+                        "convertX12Schema", (Supplier<BLauncherCmd>) ConvertX12Cmd::new),
+                Arguments.of(
+                        "convertEdifactSchema", (Supplier<BLauncherCmd>) ConvertEdifactCmd::new),
+                Arguments.of("edi", (Supplier<BLauncherCmd>) EdiCmd::new));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("commands")
+    void testPrintUsageProducesHelpText(String name, Supplier<BLauncherCmd> factory) {
+        StringBuilder stringBuilder = new StringBuilder();
+        factory.get().printUsage(stringBuilder);
+
+        String usage = stringBuilder.toString();
+        assertFalse(usage.isBlank(), "printUsage produced no text for '" + name + "'");
+        assertFalse(usage.contains("Helper text is not available."),
+                "Help resource is missing for '" + name + "': " + usage);
+        assertTrue(usage.contains("bal edi"), "Usage text for '" + name + "' looks wrong: " + usage);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("commands")
+    void testPrintLongDescProducesHelpText(String name, Supplier<BLauncherCmd> factory) {
+        StringBuilder stringBuilder = new StringBuilder();
+        factory.get().printLongDesc(stringBuilder);
+
+        assertFalse(stringBuilder.toString().isBlank(),
+                "printLongDesc appended nothing to the builder for '" + name + "'");
+    }
+
+    /**
+     * Missing mandatory options must be rejected at parse time rather than producing a blank line.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("incompleteInvocations")
+    void testMissingMandatoryOptionsAreRejected(String name, Supplier<BLauncherCmd> factory, List<String> args) {
+        CommandLine commandLine = new CommandLine(factory.get());
+        assertThrows(CommandLine.MissingParameterException.class,
+                () -> commandLine.parseArgs(args.toArray(new String[0])),
+                "Missing mandatory options should be rejected for '" + name + "'");
+    }
+
+    private static Stream<Arguments> incompleteInvocations() {
+        return Stream.of(
+                Arguments.of(
+                        "codegen without -o", (Supplier<BLauncherCmd>) CodegenCmd::new, List.of("-i", "schema.json")),
+                Arguments.of(
+                        "libgen without -p", (Supplier<BLauncherCmd>) LibgenCmd::new,
+                        List.of("-i", "schemas", "-o", "out")),
+                Arguments.of(
+                        "convertESL without -b", (Supplier<BLauncherCmd>) EslCmd::new,
+                        List.of("-i", "a.esl", "-o", "out.json")),
+                Arguments.of(
+                        "convertX12Schema without -o", (Supplier<BLauncherCmd>) ConvertX12Cmd::new,
+                        List.of("-i", "a.xsd")),
+                Arguments.of(
+                        "convertEdifactSchema without -o", (Supplier<BLauncherCmd>) ConvertEdifactCmd::new,
+                        List.of("-v", "d03a", "-t", "ORDERS")));
+    }
+
+    /**
+     * Guards the defensive check inside execute(), reached only on programmatic invocation.
+     */
+    @Test
+    void testExecuteWithoutOptionsFailsWithUsage() {
+        BLauncherException e = assertThrows(BLauncherException.class, () -> new LibgenCmd().execute());
+        String message = String.join("\n", e.getMessages());
+        assertTrue(message.contains("missing mandatory options"), "Unexpected message: " + message);
+        assertTrue(message.contains("bal edi libgen"), "Usage text was not included: " + message);
+    }
+
+    /**
+     * A non-zero exit from the bundled EDI tool must fail the command instead of being discarded.
+     */
+    @Test
+    void testFailingToolRunFailsTheCommand(@TempDir Path tempDir) {
+        Path missingSchema = tempDir.resolve("does-not-exist.json");
+        CodegenCmd cmd = new CodegenCmd();
+        new CommandLine(cmd).parseArgs(
+                "-i", missingSchema.toString(), "-o", tempDir.resolve("out.bal").toString());
+
+        BLauncherException e = assertThrows(BLauncherException.class, cmd::execute,
+                "A failing EDI tool run should fail the command");
+        assertTrue(String.join("\n", e.getMessages()).contains("EDI tool failed"),
+                "Unexpected failure message: " + e.getMessages());
+        assertFalse(Files.exists(tempDir.resolve("out.bal")), "No output should be generated");
+    }
+}

--- a/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/LibgenCmdTest.java
+++ b/edi-tools-cli/src/test/java/io/ballerina/edi/cmd/LibgenCmdTest.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.edi.cmd;
 
+import io.ballerina.cli.launcher.BLauncherException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -60,7 +62,11 @@ class LibgenCmdTest {
         LibgenCmd cmd = new LibgenCmd();
         new CommandLine(cmd).parseArgs(
                 "-p", "invalid package!", "-i", tempDir.toString(), "-o", tempDir.toString());
-        cmd.execute();
+
+        BLauncherException e = assertThrows(BLauncherException.class, cmd::execute,
+                "An invalid package name should fail the command");
+        assertTrue(String.join("\n", e.getMessages()).contains("invalid package name"),
+                "Unexpected failure message: " + e.getMessages());
 
         try (Stream<Path> outputs = Files.list(tempDir)) {
             assertEquals(0, outputs.count(), "Nothing should be generated for an invalid package name");

--- a/edi-tools/edi_tools.bal
+++ b/edi-tools/edi_tools.bal
@@ -16,13 +16,12 @@
 
 import ballerina/io;
 import ballerina/file;
-import ballerina/log;
 import editools.codegen;
 import editools.edifact;
 import editools.esl;
 import editools.x12xsd;
 
-public function main(string[] args) {
+public function main(string[] args) returns error? {
 
     string usage = string 
 `NAME
@@ -137,22 +136,21 @@ EXAMPLES
     if mode == "codegen" {
         if args.length() != 3 {
             io:println(usage);
-            return;
+            return error("Invalid number of arguments given for the 'codegen' mode");
         }
         json|error mappingJson = io:fileReadJson(args[1].trim());
         if mappingJson is error {
-            log:printError("Error reading schema json file: " + mappingJson.message());
-            return;
+            return error("Error reading schema json file: " + mappingJson.message(), mappingJson);
         }
         error? e = codegen:generateCodeForSchema(mappingJson, args[2].trim());
         if e is error {
-            log:printError("Error generating code: " + e.message());
+            return error("Error generating code: " + e.message(), e);
         }
 
     } else if mode == "libgen" {
         if !(args.length() == 5 || args.length() == 6) {
             io:println(usage);
-            return;
+            return error("Invalid number of arguments given for the 'libgen' mode");
         }
         codegen:LibData libdata = {
             orgName: args[1],
@@ -163,16 +161,20 @@ EXAMPLES
         };
         error? e = codegen:generateLibrary(libdata);
         if e is error {
-            log:printError("Error generating library: " + e.message());
+            return error("Error generating library: " + e.message(), e);
         }
 
     } else if mode == "convertESL" {
+        if args.length() != 4 {
+            io:println(usage);
+            return error("Invalid number of arguments given for the 'convertESL' mode");
+        }
         string eslPath = args[1].trim();
         string basedefPath = args[2].trim();
         string outputPath = args[3].trim();
         error? e = esl:convertEsl(eslPath, basedefPath, outputPath);
         if e is error {
-            log:printError("Error converting ESL: " + e.message());
+            return error("Error converting ESL: " + e.message(), e);
         }
 
     } else if mode == "convertX12Schema" {
@@ -197,15 +199,13 @@ EXAMPLES
 
             if (collection) {
                 if (!isInputDir || !isOutputDir) {
-                    io:println("In collection mode, both output and input should be a directories");
-                    return;
+                    return error("In collection mode, both output and input should be a directories");
                 }
                 check x12xsd:convertFromX12CollectionAndWrite(inputPath, outputPath, headers, segDetlPath);
             } else {
                 if (headers) {
                     if (!isInputDir) {
-                        io:println("In header mode, input should be a directory containing header and message schema files");
-                        return;
+                        return error("In header mode, input should be a directory containing header and message schema files");
                     }
                     string outputPathGenerated = outputPath;
                     if (isOutputDir) {
@@ -215,20 +215,19 @@ EXAMPLES
                     check x12xsd:convertFromX12WithHeadersAndWrite(inputPath, outputPathGenerated, segDetlPath);
                 } else {
                     if (isInputDir || isOutputDir) {
-                        io:println("Collection mode or header mode not selected, both input and output should be files");
-                        return;
+                        return error("Collection mode or header mode not selected, both input and output should be files");
                     }
                     check x12xsd:convertFromX12XsdAndWrite(inputPath, outputPath, segDetlPath);
                 }
             }
         } on fail error e {
-            log:printError("Error converting X12 schema: " + e.message());
+            return error("Error converting X12 schema: " + e.message(), e);
         }
     } else if mode == "convertEdifactSchema" {
         do {
-            if args.length() < 3 {
+            if args.length() < 4 {
                 io:println(usage);
-                return;
+                return error("Invalid number of arguments given for the 'convertEdifactSchema' mode");
             }
             string version = args[1].trim(); // ex: d10a
             string 'type = args[2].trim(); // ex: INVOIC
@@ -238,9 +237,10 @@ EXAMPLES
             check edifact:convertEdifactToEdi(version, outputPath, 'type == "" ? () : 'type,
                     inputPath == "" ? () : inputPath);
         } on fail error e {
-            log:printError("Error converting EDIFACT schema: " + e.message());
+            return error("Error converting EDIFACT schema: " + e.message(), e);
         }
     } else {
         io:println(usage);
+        return error("Unknown mode: " + mode);
     }
 }

--- a/edi-tools/edi_tools.bal
+++ b/edi-tools/edi_tools.bal
@@ -199,7 +199,7 @@ EXAMPLES
 
             if (collection) {
                 if (!isInputDir || !isOutputDir) {
-                    return error("In collection mode, both output and input should be a directories");
+                    return error("In collection mode, both output and input should be directories");
                 }
                 check x12xsd:convertFromX12CollectionAndWrite(inputPath, outputPath, headers, segDetlPath);
             } else {

--- a/edi-tools/modules/codegen/libgen.bal
+++ b/edi-tools/modules/codegen/libgen.bal
@@ -26,6 +26,12 @@ public type LibData record {|
 
     boolean versioned;
     string libPath = "";
+    // Set once this run has taken ownership of libPath, by creating it or by finding it empty.
+    // Only then may a failed run clean up, and only what this run wrote.
+    boolean libDirClaimed = false;
+    // Set when this run created libPath, so cleanup can remove the directory itself rather
+    // than leaving a caller-provided one behind.
+    boolean libDirCreated = false;
     string importsBlock = "";
     string exportsBlock = "";
     string enumBlock = "";
@@ -46,14 +52,18 @@ public type LibData record {|
 # + libdata - Data structure containing the following inputs for the library: orgName, libName, outputPath, schemaPath
 # + return - Returns error if library generation is not successful
 public function generateLibrary(LibData libdata) returns error? {
-    check createLibStructure(libdata);
-    error? generationResult = generatePackageContent(libdata);
-    if generationResult is error {
+    error? result = buildPackage(libdata);
+    if result is error {
         // Nothing usable was produced, so the half-written package is removed rather than
         // left behind without a Ballerina.toml.
         removePartialLibrary(libdata);
-        return generationResult;
+        return result;
     }
+}
+
+function buildPackage(LibData libdata) returns error? {
+    check createLibStructure(libdata);
+    check generatePackageContent(libdata);
 }
 
 function generatePackageContent(LibData libdata) returns error? {
@@ -77,18 +87,34 @@ function generatePackageContent(LibData libdata) returns error? {
     }
 }
 
-# Removes the package directory created for this run. Only the generated package directory is
-# removed, never the output directory it sits in, which may hold unrelated content.
+# Removes what this run wrote into the package directory. Only content this run created is
+# removed: never the output directory it sits in, and never a directory the caller provided,
+# which is emptied but kept.
 #
 # + libdata - Data structure holding the generated library path
 function removePartialLibrary(LibData libdata) {
-    if libdata.libPath == "" {
+    if !libdata.libDirClaimed || libdata.libPath == "" {
         return;
     }
-    file:Error? removed = file:remove(libdata.libPath, file:RECURSIVE);
+    if libdata.libDirCreated {
+        reportFailedRemoval(libdata.libPath, file:remove(libdata.libPath, file:RECURSIVE));
+        return;
+    }
+    // The caller provided an empty directory, so it is restored to that state rather than removed.
+    file:MetaData[]|file:Error entries = file:readDir(libdata.libPath);
+    if entries is file:Error {
+        reportFailedRemoval(libdata.libPath, entries);
+        return;
+    }
+    foreach file:MetaData entry in entries {
+        reportFailedRemoval(entry.absPath, file:remove(entry.absPath, file:RECURSIVE));
+    }
+}
+
+function reportFailedRemoval(string path, file:Error? removed) {
     if removed is file:Error {
-        io:fprintln(io:stderr, string `WARNING: could not remove the incomplete package at ` +
-                string `${libdata.libPath}: ${removed.message()}`);
+        io:fprintln(io:stderr, string `WARNING: could not remove ${path} from the incomplete ` +
+                string `package: ${removed.message()}`);
     }
 }
 
@@ -97,11 +123,14 @@ function createLibStructure(LibData libdata) returns error? {
     if check file:test(libdata.libPath, file:EXISTS) {
         file:MetaData[] files = check file:readDir(libdata.libPath);
         if files.length() > 0 {
+            // The directory holds content this run did not write, so it is never cleaned up.
             return error(string `Target library path ${libdata.libPath} is not empty. Please provide an empty directory to create the library.`);
         }
     } else {
         check file:createDir(libdata.libPath, file:RECURSIVE);
+        libdata.libDirCreated = true;
     }
+    libdata.libDirClaimed = true;
     libdata.exportsBlock = "\"" + libdata.libName + "\"";
     check copyNonTemplatedFiles(libdata);
 }

--- a/edi-tools/modules/codegen/libgen.bal
+++ b/edi-tools/modules/codegen/libgen.bal
@@ -47,10 +47,24 @@ public type LibData record {|
 # + return - Returns error if library generation is not successful
 public function generateLibrary(LibData libdata) returns error? {
     check createLibStructure(libdata);
+    error? generationResult = generatePackageContent(libdata);
+    if generationResult is error {
+        // Nothing usable was produced, so the half-written package is removed rather than
+        // left behind without a Ballerina.toml.
+        removePartialLibrary(libdata);
+        return generationResult;
+    }
+}
+
+function generatePackageContent(LibData libdata) returns error? {
     if libdata.versioned {
         check generateCodeFromFolders(libdata);
     } else {
         check generateCodeFromSchemas(libdata, "", ());
+    }
+    if libdata.ediNames.length() == 0 {
+        return error(string `No EDI schemas were found in ${libdata.schemaPath}. ` +
+                string `Provide a folder containing EDI schema files with the '.json' extension.`);
     }
     check createBalLib(libdata);
     if libdata.hasEnvelope {
@@ -60,6 +74,21 @@ public function generateLibrary(LibData libdata) returns error? {
                 "reject the new `envelope` field with `field cannot be added to " +
                 "the closed record 'edi:EdiSchema'`. The generated Ballerina.toml " +
                 "pins `ballerina/edi` >= " + EDI_RUNTIME_VERSION + " accordingly.");
+    }
+}
+
+# Removes the package directory created for this run. Only the generated package directory is
+# removed, never the output directory it sits in, which may hold unrelated content.
+#
+# + libdata - Data structure holding the generated library path
+function removePartialLibrary(LibData libdata) {
+    if libdata.libPath == "" {
+        return;
+    }
+    file:Error? removed = file:remove(libdata.libPath, file:RECURSIVE);
+    if removed is file:Error {
+        io:fprintln(io:stderr, string `WARNING: could not remove the incomplete package at ` +
+                string `${libdata.libPath}: ${removed.message()}`);
     }
 }
 
@@ -82,23 +111,48 @@ function generateCodeFromFolders(LibData libdata) returns error? {
     foreach file:MetaData schemaFolder in schemaFolders {
         string schemaFolderName = check file:basename(schemaFolder.absPath);
         if !schemaFolder.dir {
-            return error(string `Schema path must only contain folders. Path: ${libdata.schemaPath}. Item: ${schemaFolderName}`);
+            printSkipped(schemaFolderName, "a version folder was expected");
+            continue;
         }
         file:MetaData[] schemaFiles = check file:readDir(schemaFolder.absPath);
         check generateCodeFromSchemas(libdata, schemaFolderName, schemaFiles);
-    }    
+    }
 }
 
 function generateCodeFromSchemas(LibData libdata, string ediVersion, file:MetaData[]? schemaItems) returns error? {
     file:MetaData[] schemaFiles = schemaItems != () ? schemaItems : check file:readDir(libdata.schemaPath);
     foreach file:MetaData schemaFile in schemaFiles {
-        string ediName = check file:basename(schemaFile.absPath);
-        if ediName.endsWith(".json") {
-            ediName = ediName.substring(0, ediName.length() - ".json".length());
+        string fileName = check file:basename(schemaFile.absPath);
+        // Only '.json' files are treated as schemas. Anything else in the folder is reported and
+        // skipped, so unrelated files do not fail the whole run. A '.json' file that cannot be
+        // read is an intended schema, and does fail the run.
+        if schemaFile.dir {
+            printSkipped(fileName, "it is a directory");
+            continue;
         }
-        json schemaJson = check io:fileReadJson(schemaFile.absPath);
-        check generateEDIFileSpecificCode(ediName, ediVersion, schemaJson, libdata);
+        if !fileName.toLowerAscii().endsWith(".json") {
+            printSkipped(fileName, "it is not a '.json' file");
+            continue;
+        }
+        string ediName = fileName.substring(0, fileName.length() - ".json".length());
+        json|error schemaJson = io:fileReadJson(schemaFile.absPath);
+        if schemaJson is error {
+            return error(string `Error reading EDI schema '${fileName}': ${schemaJson.message()}`, schemaJson);
+        }
+        error? generated = generateEDIFileSpecificCode(ediName, ediVersion, schemaJson, libdata);
+        if generated is error {
+            return error(string `Error generating code for EDI schema '${fileName}': ${generated.message()}`,
+                    generated);
+        }
     }
+}
+
+# Reports a folder entry that is not treated as an EDI schema.
+#
+# + name - Name of the skipped entry
+# + reason - Why the entry was skipped
+function printSkipped(string name, string reason) {
+    io:fprintln(io:stderr, string `WARNING: skipping '${name}' because ${reason}.`);
 }
 
 function createBalLib(LibData libdata) returns error? {

--- a/edi-tools/modules/codegen/tests/libgen_schema_selection_test.bal
+++ b/edi-tools/modules/codegen/tests/libgen_schema_selection_test.bal
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/io;
+import ballerina/test;
+
+// Sets up a schema folder and an output folder under a fresh temp directory.
+function prepareLibgenDirs() returns [string, string]|error {
+    string tmp = check file:createTempDir();
+    string schemaPath = check file:joinPath(tmp, "schemas");
+    check file:createDir(schemaPath, file:RECURSIVE);
+    string outputPath = check file:joinPath(tmp, "out");
+    check file:createDir(outputPath, file:RECURSIVE);
+    return [schemaPath, outputPath];
+}
+
+function runLibgen(string schemaPath, string outputPath, string libName) returns error? {
+    LibData libdata = {
+        orgName: "testorg",
+        libName: libName,
+        schemaPath: schemaPath,
+        outputPath: outputPath,
+        versioned: false
+    };
+    return generateLibrary(libdata);
+}
+
+@test:Config {}
+function testNonJsonFilesAreSkipped() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    check io:fileWriteJson(check file:joinPath(schemaPath, "SIMPLE.json"), plainSchemaJson);
+    // The kind of stray file a Windows download leaves behind next to the schemas.
+    check io:fileWriteString(check file:joinPath(schemaPath, "SIMPLE.json:Zone.Identifier"),
+            "[ZoneTransfer]\nZoneId=3\n");
+    check io:fileWriteString(check file:joinPath(schemaPath, "notes.txt"), "not a schema");
+    check file:createDir(check file:joinPath(schemaPath, "nested"), file:RECURSIVE);
+
+    check runLibgen(schemaPath, outputPath, "skiplib");
+
+    string libPath = check file:joinPath(outputPath, "skiplib");
+    test:assertTrue(check file:test(check file:joinPath(libPath, "Ballerina.toml"), file:EXISTS),
+            "A stray file must not stop the package from being generated");
+    test:assertTrue(check file:test(check file:joinPath(libPath, "modules", "mSIMPLE"), file:EXISTS),
+            "The valid schema should still produce its module");
+}
+
+@test:Config {}
+function testUnparseableJsonSchemaFailsAndRemovesPackage() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    check io:fileWriteJson(check file:joinPath(schemaPath, "SIMPLE.json"), plainSchemaJson);
+    // A '.json' file is an intended schema, so a broken one must fail the run.
+    check io:fileWriteString(check file:joinPath(schemaPath, "BROKEN.json"), "[ZoneTransfer]\nZoneId=3\n");
+
+    error? result = runLibgen(schemaPath, outputPath, "brokenlib");
+    test:assertTrue(result is error, "An unparseable '.json' schema must fail the run");
+    if result is error {
+        test:assertTrue(result.message().includes("BROKEN.json"),
+                "The failure should name the offending schema: " + result.message());
+    }
+    test:assertFalse(check file:test(check file:joinPath(outputPath, "brokenlib"), file:EXISTS),
+            "The incomplete package must be removed");
+}
+
+@test:Config {}
+function testNoSchemasFailsAndRemovesPackage() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    check io:fileWriteString(check file:joinPath(schemaPath, "readme.md"), "no schemas here");
+
+    error? result = runLibgen(schemaPath, outputPath, "emptylib");
+    test:assertTrue(result is error, "A folder with no '.json' schemas must fail the run");
+    if result is error {
+        test:assertTrue(result.message().includes("No EDI schemas were found"),
+                "Unexpected failure message: " + result.message());
+    }
+    test:assertFalse(check file:test(check file:joinPath(outputPath, "emptylib"), file:EXISTS),
+            "No package directory should be left behind");
+}
+
+@test:Config {}
+function testOutputDirectoryIsNotRemovedOnFailure() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    // Cleanup must remove only the generated package, never the output folder around it.
+    string sibling = check file:joinPath(outputPath, "keep.txt");
+    check io:fileWriteString(sibling, "unrelated content");
+
+    error? result = runLibgen(schemaPath, outputPath, "gonelib");
+    test:assertTrue(result is error, "An empty schema folder must fail the run");
+    test:assertTrue(check file:test(outputPath, file:EXISTS), "The output directory must survive");
+    test:assertTrue(check file:test(sibling, file:EXISTS), "Unrelated output content must survive");
+}

--- a/edi-tools/modules/codegen/tests/libgen_schema_selection_test.bal
+++ b/edi-tools/modules/codegen/tests/libgen_schema_selection_test.bal
@@ -91,6 +91,37 @@ function testNoSchemasFailsAndRemovesPackage() returns error? {
 }
 
 @test:Config {}
+function testCallerProvidedEmptyDirectoryIsKeptButEmptied() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    // The caller pre-creates the package directory, so cleanup must empty it, not remove it.
+    string libPath = check file:joinPath(outputPath, "providedlib");
+    check file:createDir(libPath, file:RECURSIVE);
+
+    error? result = runLibgen(schemaPath, outputPath, "providedlib");
+    test:assertTrue(result is error, "An empty schema folder must fail the run");
+    test:assertTrue(check file:test(libPath, file:EXISTS),
+            "A caller-provided directory must not be removed");
+    file:MetaData[] leftovers = check file:readDir(libPath);
+    test:assertEquals(leftovers.length(), 0, "The caller-provided directory should be left empty");
+}
+
+@test:Config {}
+function testNonEmptyTargetIsNeverCleanedUp() returns error? {
+    [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
+    check io:fileWriteJson(check file:joinPath(schemaPath, "SIMPLE.json"), plainSchemaJson);
+    // Pre-existing content belongs to the caller and must survive the rejected run.
+    string libPath = check file:joinPath(outputPath, "occupiedlib");
+    check file:createDir(libPath, file:RECURSIVE);
+    string preExisting = check file:joinPath(libPath, "mine.txt");
+    check io:fileWriteString(preExisting, "do not delete me");
+
+    error? result = runLibgen(schemaPath, outputPath, "occupiedlib");
+    test:assertTrue(result is error, "A non-empty target directory must be rejected");
+    test:assertTrue(check file:test(preExisting, file:EXISTS),
+            "Content this run did not write must never be removed");
+}
+
+@test:Config {}
 function testOutputDirectoryIsNotRemovedOnFailure() returns error? {
     [string, string] [schemaPath, outputPath] = check prepareLibgenDirs();
     // Cleanup must remove only the generated package, never the output folder around it.


### PR DESCRIPTION
## Purpose

Fixes ballerina-platform/ballerina-library#8982.

No `bal edi` subcommand reported failure in a usable way: every command exited `0` regardless of
outcome, a missing mandatory option printed a single blank line, and two commands discarded the
child process's stderr entirely.

Reproducing the original report — `bal edi libgen -i ../resources -o .`, missing the required `-p`
— produced exactly one newline byte on stdout, nothing on stderr, exit `0`, and no output.

## What was wrong

| Defect | Where |
|---|---|
| `printUsage(StringBuilder)` had an empty body, so callers printed `""` | all six command classes |
| `printLongDesc` appended to `printStream` instead of its builder | all six command classes |
| No `@Option` marked `required`, so picocli never reported a missing option | all five subcommands |
| `process.waitFor()`'s exit code discarded; `execute()` returned normally | all six command classes |
| `editools`' `main` only logged errors, so the child also exited `0` | `edi-tools/edi_tools.bal` |
| No `inheritIO()`, so the child's stderr went to a pipe nobody read | `EslCmd`, `ConvertX12Cmd` |

The last one meant `convertESL` and `convertX12Schema` printed **nothing at all** on a hard failure
— every `log:printError` from the Ballerina layer was destroyed before reaching the user.

## What changed

- **`printUsage` / `printLongDesc`** now fill the passed `StringBuilder` from the `cli-docs/*.help`
  resources. The help text was already shipped and already read correctly by `printLongDesc`, but
  only reachable via `bal help edi <cmd>` — never on a validation failure.
- **`required = true`** on the mandatory options, so picocli rejects incomplete invocations itself.
  `Main` already converts picocli's `ParameterException` into a usage error with a non-zero exit.
- **Exit codes propagate.** A non-zero status from the bundled tool now raises a
  `BLauncherException`, which `bal` prints and exits non-zero on.
- **`editools`' `main` returns `error?`.** The branches that printed a message and returned now
  return an error, so the child exits non-zero too. This is what makes the Java-side exit-code
  check meaningful.
- **All commands `inheritIO()`.** The `available()`/`read` block is removed everywhere: with
  inherited IO it was redundant, it truncated child output to whatever happened to be buffered, and
  with a never-drained stderr pipe it risked deadlocking a child that wrote more than the pipe
  buffer (~64 KB) — reachable via collection-mode `convertX12Schema` over a large directory.
- **`EdiCmdUtils`** holds the shared help-loading and tool-invocation logic, replacing six
  near-identical copies. Net −364/+382 lines with the new tests included; the command classes
  themselves shrink substantially.

One latent bug fixed in passing: the `convertEdifactSchema` branch guarded on `args.length() < 3`
but indexed `args[3]`, so a 3-argument invocation would have panicked. It now requires 4.

Issue #8982 also lists a sixth item — `libgen` parsing every file in the input directory as a
schema and aborting into a partially-written, unbuildable package. That is a behaviour change with
its own test implications and is deliberately **not** in this PR; it stays tracked on the issue.

## Testing

New `ErrorReportingTest` (20 cases) covers the reported defects directly:

- `printUsage` and `printLongDesc` produce non-blank help text for all six commands
- missing mandatory options raise `MissingParameterException` for all five subcommands
- the defensive in-`execute()` check fails with usage text included
- a failing tool run raises `BLauncherException` and generates no output

That last test is the end-to-end proof of both layers: it spawns the real
`bal run editools.jar -- codegen <missing-file> <out>` and passes only because the child now exits
non-zero, which requires the `edi_tools.bal` change. Before this PR that child exited `0`.

`LibgenCmdTest.testLibgenRejectsInvalidPackageName` now asserts the failure instead of a silent
return, and `EdiCmdTest.testNoArgumentInvocationRunsEdiTool` asserts no exception rather than
grepping stdout for a message the command no longer prints.

`./gradlew build --continue`: everything passes except `ConvertEdifactCmdTest` and the Ballerina
`testEdifactConversion`, which both fetch the EDIFACT spec from `service.unece.org` — that host
returns HTTP 403 from my sandbox, and both fail identically on an unmodified checkout. Their
network dependency is documented in `ConvertEdifactCmdTest`'s own javadoc. They should pass on CI.

## Manual verification

The unit tests spawn the real child process, so the behaviour is covered without installing the
tool. I did **not** run `./gradlew buildEDIPackage`, since that pushes into `~/.ballerina` and
rewrites `bal-tools.toml`, replacing the reviewer's working `bal edi` install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved failure reporting for all `bal edi` commands.
- Marked mandatory options as required and added usage output for missing options.
- Propagated EDI tool and `editools` failures through non-zero exits.
- Preserved child-process output by using inherited IO.
- Consolidated help loading and process execution in `EdiCmdUtils`.
- Fixed EDIFACT argument validation.
- Added error-reporting test coverage.
- Updated `libgen` to skip non-schema entries, report invalid schemas, clean up failed generated packages, and reject unusable schema inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->