### PR TITLE
Expose the envelope functions in a libgen package's default module

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,27 @@ public function main() returns error? {
 }
 ```
 
+The package's default module additionally offers a name-dispatched facade over every schema in the package — `fromEdiString(ediText, ediName)` and `toEdiString(data, ediName)` — which is useful when the EDI type is only known at runtime. When at least one schema declares an envelope, the facade also covers the envelope functions:
+
+```ballerina
+import ballerina/io;
+import citymart/porder;
+import citymart/porder.m850;
+
+public function main() returns error? {
+    string orderText = check io:fileReadString("orders/order10.edi");
+
+    // Route on the envelope headers without parsing the transaction bodies.
+    anydata headers = check porder:headersFromEdiString(orderText, porder:EDI_850);
+
+    any interchange = check porder:interchangeFromEdiString(orderText, porder:EDI_850);
+    m850:Purchase_OrderInterchange typed = check interchange.ensureType();
+    io:println(typed.groups.length());
+}
+```
+
+Because the facade is keyed by name, it hands back the module's typed record boxed in `anydata` (headers) or `any` (interchanges); narrow it with `ensureType` as above. Interchanges are `any` rather than `anydata` because `<Name>Transaction.body` is `<Name>|error`, and a value holding an error is not `anydata`. Call `hasEnvelope(ediName)` to test whether a given EDI type supports these functions — for a schema without an envelope they return an error.
+
 Because trading partners often use variations of a standard format, a partner-specific package can be generated from partner-specific schemas.
 
 ### Running a generated package as a REST service

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Generate envelope-aware EDI schemas and typed envelope wrappers (BEP-1441)](https://github.com/ballerina-platform/ballerina-spec/issues/1441)
 - [Populate the schema envelope in X12 headers mode so `convertX12Schema -H` output works with envelope-aware APIs (BEP-1441)](https://github.com/ballerina-platform/ballerina-spec/issues/1441)
+- [Expose the envelope-aware functions in the default module of a `libgen` package (BEP-1441)](https://github.com/ballerina-platform/ballerina-spec/issues/1441)
 
 ## [2.0.0] - 2024-05-29
 

--- a/edi-tools-package/README.md
+++ b/edi-tools-package/README.md
@@ -165,6 +165,27 @@ public function main() returns error? {
 }
 ```
 
+The package's default module additionally offers a name-dispatched facade over every schema in the package — `fromEdiString(ediText, ediName)` and `toEdiString(data, ediName)` — which is useful when the EDI type is only known at runtime. When at least one schema declares an envelope, the facade also covers the envelope functions:
+
+```ballerina
+import ballerina/io;
+import citymart/porder;
+import citymart/porder.m850;
+
+public function main() returns error? {
+    string orderText = check io:fileReadString("orders/order10.edi");
+
+    // Route on the envelope headers without parsing the transaction bodies.
+    anydata headers = check porder:headersFromEdiString(orderText, porder:EDI_850);
+
+    any interchange = check porder:interchangeFromEdiString(orderText, porder:EDI_850);
+    m850:Purchase_OrderInterchange typed = check interchange.ensureType();
+    io:println(typed.groups.length());
+}
+```
+
+Because the facade is keyed by name, it hands back the module's typed record boxed in `anydata` (headers) or `any` (interchanges); narrow it with `ensureType` as above. Interchanges are `any` rather than `anydata` because `<Name>Transaction.body` is `<Name>|error`, and a value holding an error is not `anydata`. Call `hasEnvelope(ediName)` to test whether a given EDI type supports these functions — for a schema without an envelope they return an error.
+
 Because trading partners often use variations of a standard format, a partner-specific package can be generated from partner-specific schemas.
 
 ### Running a generated package as a REST service

--- a/edi-tools/modules/codegen/libgen.bal
+++ b/edi-tools/modules/codegen/libgen.bal
@@ -33,6 +33,9 @@ public type LibData record {|
     string ediSerializers = "";
     string[] ediNames = [];
     boolean hasEnvelope = false;
+    string envelopeHeadersDeserializers = "";
+    string envelopeInterchangeDeserializers = "";
+    string envelopeInterchangeSerializers = "";
 |};
 
 # Generates a Ballerina library project containing:
@@ -121,7 +124,8 @@ function generateEDIFileSpecificCode(string ediName, string ediVersion, json map
     libdata.ediNames.push(completeEdiName);
     edi:EdiSchema ediMapping = check edi:getSchema(mappingJson);
     ediMapping.name = "EDI_" + completeEdiName + "_" + ediMapping.name;
-    if ediMapping.envelope is edi:EdiEnvelopeSchema {
+    boolean schemaHasEnvelope = ediMapping.envelope is edi:EdiEnvelopeSchema;
+    if schemaHasEnvelope {
         libdata.hasEnvelope = true;
     }
 
@@ -131,7 +135,7 @@ function generateEDIFileSpecificCode(string ediName, string ediVersion, json map
     string recordsPath = check file:joinPath(modulePath, "G_" + ediName + ".bal");
     check generateCodeForSchema(ediMapping, recordsPath);
 
-    string transformer = generateTransformerCode(ediName, ediMapping.name);
+    string transformer = generateTransformerCode(ediName, ediMapping.name, schemaHasEnvelope);
     check io:fileWriteString(check file:joinPath(modulePath, "transformer.bal"), transformer);
 
     libdata.importsBlock += "\n" + string `import ${libdata.libName}.${moduleName};`;
@@ -141,6 +145,17 @@ function generateEDIFileSpecificCode(string ediName, string ediVersion, json map
         string `    "${completeEdiName}": ${moduleName}:transformFromEdiString`;
     libdata.ediSerializers += (libdata.ediSerializers.length() > 0 ? ",\n" : "") +
         string `    "${completeEdiName}": ${moduleName}:transformToEdiString`;
+
+    // Only enveloped schemas are registered in the envelope dispatch maps — a
+    // plain schema's module has no envelope functions to point at.
+    if schemaHasEnvelope {
+        libdata.envelopeHeadersDeserializers += (libdata.envelopeHeadersDeserializers.length() > 0 ? ",\n" : "") +
+            string `    "${completeEdiName}": ${moduleName}:transformHeadersFromEdiString`;
+        libdata.envelopeInterchangeDeserializers += (libdata.envelopeInterchangeDeserializers.length() > 0 ? ",\n" : "") +
+            string `    "${completeEdiName}": ${moduleName}:transformInterchangeFromEdiString`;
+        libdata.envelopeInterchangeSerializers += (libdata.envelopeInterchangeSerializers.length() > 0 ? ",\n" : "") +
+            string `    "${completeEdiName}": ${moduleName}:transformInterchangeToEdiString`;
+    }
 }
 
 function writeLibFile(string content, string targetName, LibData libdata) returns error? {

--- a/edi-tools/modules/codegen/maincode_gen.bal
+++ b/edi-tools/modules/codegen/maincode_gen.bal
@@ -97,10 +97,11 @@ public isolated function hasEnvelope(EDI_NAME ediName) returns boolean {
 }
 
 # Parse only the envelope header segments of the given EDI string.
+# Narrow the result with ensureType.
 #
 # + ediText - EDI string to be parsed
 # + ediName - EDI type name
-# + return - Envelope headers record, or error
+# + return - Envelope headers record of the EDI type boxed as anydata, or error
 public isolated function headersFromEdiString(string ediText, EDI_NAME ediName) returns anydata|error {
     EdiHeadersDeserialize? headersDeserialize = envelopeHeadersDeserializers[ediName];
     if headersDeserialize is () {
@@ -111,10 +112,11 @@ public isolated function headersFromEdiString(string ediText, EDI_NAME ediName) 
 
 # Parse the full envelope hierarchy of the given EDI string.
 # A malformed transaction body becomes an error in that transaction's body field.
+# Narrow the result with ensureType.
 #
 # + ediText - EDI string to be parsed
 # + ediName - EDI type name
-# + return - Interchange record, or error
+# + return - Interchange record of the EDI type boxed as any, or error
 public isolated function interchangeFromEdiString(string ediText, EDI_NAME ediName) returns any|error {
     EdiInterchangeDeserialize? interchangeDeserialize = envelopeInterchangeDeserializers[ediName];
     if interchangeDeserialize is () {

--- a/edi-tools/modules/codegen/maincode_gen.bal
+++ b/edi-tools/modules/codegen/maincode_gen.bal
@@ -30,7 +30,7 @@ public isolated function getEDINames() returns string[] {
 }
 
 # Convert EDI string to Ballerina record.
-# 
+#
 # + ediText - EDI string to be converted
 # + ediName - EDI type name
 # + return - Ballerina record or error
@@ -43,7 +43,7 @@ public isolated function fromEdiString(string ediText, EDI_NAME ediName) returns
 }
 
 # Convert Ballerina record to EDI string.
-# 
+#
 # + data - Ballerina record to be converted
 # + ediName - EDI type name
 # + return - EDI string or error
@@ -54,7 +54,7 @@ public isolated function toEdiString(anydata data, EDI_NAME ediName) returns str
     }
     return ediSerialize(data);
 }
-
+${generateEnvelopeMainCode(libdata)}
 final readonly & map<EdiDeserialize> ediDeserializers = {
     ${libdata.ediDeserializers}
 };
@@ -64,4 +64,88 @@ final readonly & map<EdiSerialize> ediSerializers = {
 };
     `;
 
+}
+
+# Renders the envelope-aware half of the default module: name-dispatched
+# counterparts of the `headersFromEdiString` / `interchangeFromEdiString` /
+# `interchangeToEdiString` functions that `generateCodeForSchema` emits into each
+# EDI module. Only the EDI types whose schema declares an envelope are
+# registered, so a library mixing enveloped and plain schemas gets a dispatcher
+# that errors for the plain ones rather than a module that does not compile.
+#
+# The interchange functions are typed `any` rather than `anydata` because
+# `<Name>Transaction.body` is `<Name>|error` (fail-safe parsing) and a value
+# holding an error is not `anydata`.
+#
+# + libdata - Library data holding the per-EDI-type envelope dispatch entries
+# + return - Ballerina code for the envelope functions, or "" if no schema has an envelope
+function generateEnvelopeMainCode(LibData libdata) returns string {
+    if !libdata.hasEnvelope {
+        return "";
+    }
+    return string `
+type EdiHeadersDeserialize isolated function (string) returns anydata|error;
+type EdiInterchangeDeserialize isolated function (string) returns any|error;
+type EdiInterchangeSerialize isolated function (any) returns string|error;
+
+# Check whether the given EDI type defines an envelope.
+#
+# + ediName - EDI type name
+# + return - true if the EDI type supports the envelope functions
+public isolated function hasEnvelope(EDI_NAME ediName) returns boolean {
+    return envelopeHeadersDeserializers.hasKey(ediName);
+}
+
+# Parse only the envelope header segments of the given EDI string.
+#
+# + ediText - EDI string to be parsed
+# + ediName - EDI type name
+# + return - Envelope headers record, or error
+public isolated function headersFromEdiString(string ediText, EDI_NAME ediName) returns anydata|error {
+    EdiHeadersDeserialize? headersDeserialize = envelopeHeadersDeserializers[ediName];
+    if headersDeserialize is () {
+        return error("EDI type does not define an envelope: " + ediName);
+    }
+    return headersDeserialize(ediText);
+}
+
+# Parse the full envelope hierarchy of the given EDI string.
+# A malformed transaction body becomes an error in that transaction's body field.
+#
+# + ediText - EDI string to be parsed
+# + ediName - EDI type name
+# + return - Interchange record, or error
+public isolated function interchangeFromEdiString(string ediText, EDI_NAME ediName) returns any|error {
+    EdiInterchangeDeserialize? interchangeDeserialize = envelopeInterchangeDeserializers[ediName];
+    if interchangeDeserialize is () {
+        return error("EDI type does not define an envelope: " + ediName);
+    }
+    return interchangeDeserialize(ediText);
+}
+
+# Serialize an interchange record into EDI text.
+#
+# + msg - Interchange record to be converted
+# + ediName - EDI type name
+# + return - EDI string or error
+public isolated function interchangeToEdiString(any msg, EDI_NAME ediName) returns string|error {
+    EdiInterchangeSerialize? interchangeSerialize = envelopeInterchangeSerializers[ediName];
+    if interchangeSerialize is () {
+        return error("EDI type does not define an envelope: " + ediName);
+    }
+    return interchangeSerialize(msg);
+}
+
+final readonly & map<EdiHeadersDeserialize> envelopeHeadersDeserializers = {
+    ${libdata.envelopeHeadersDeserializers}
+};
+
+final readonly & map<EdiInterchangeDeserialize> envelopeInterchangeDeserializers = {
+    ${libdata.envelopeInterchangeDeserializers}
+};
+
+final readonly & map<EdiInterchangeSerialize> envelopeInterchangeSerializers = {
+    ${libdata.envelopeInterchangeSerializers}
+};
+`;
 }

--- a/edi-tools/modules/codegen/tests/libgen_envelope_test.bal
+++ b/edi-tools/modules/codegen/tests/libgen_envelope_test.bal
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/io;
+import ballerina/os;
+import ballerina/test;
+
+// A schema without an `envelope`, so the generated library mixes enveloped and
+// plain EDI types — the plain one must stay out of the envelope dispatch maps.
+final readonly & json plainSchemaJson = {
+    "name": "Simple",
+    "tag": "Simple",
+    "delimiters": {
+        "segment": "'",
+        "field": "+",
+        "component": ":",
+        "subcomponent": "NOT_USED",
+        "repetition": "NOT_USED"
+    },
+    "segments": [
+        {
+            "code": "BGM",
+            "tag": "BeginningOfMessage",
+            "minOccurances": 1,
+            "maxOccurances": 1,
+            "fields": [
+                {"tag": "code"},
+                {"tag": "documentNumber"}
+            ]
+        }
+    ]
+};
+
+// Generates a library from ORDERS (enveloped) + SIMPLE (plain) and returns the
+// library root. Both schemas are written to a temp folder so `generateLibrary`
+// walks them the same way the CLI does.
+function generateMixedLibrary(string libName) returns [string, string]|error {
+    string tmp = check file:createTempDir();
+    string schemaPath = check file:joinPath(tmp, "schemas");
+    check file:createDir(schemaPath, file:RECURSIVE);
+    check io:fileWriteJson(check file:joinPath(schemaPath, "ORDERS.json"), envelopeSchemaJson);
+    check io:fileWriteJson(check file:joinPath(schemaPath, "SIMPLE.json"), plainSchemaJson);
+
+    string outputPath = check file:joinPath(tmp, "out");
+    check file:createDir(outputPath, file:RECURSIVE);
+
+    LibData libdata = {
+        orgName: "wso2test",
+        libName: libName,
+        outputPath: outputPath,
+        schemaPath: schemaPath,
+        versioned: false
+    };
+    check generateLibrary(libdata);
+    return [tmp, check file:joinPath(outputPath, libName)];
+}
+
+@test:Config {}
+function testLibgenDefaultModuleEnvelopeFns() returns error? {
+    [string, string] [tmp, libPath] = check generateMixedLibrary("mixedlib");
+    string mainModule = check io:fileReadString(check file:joinPath(libPath, "mixedlib.bal"));
+
+    // The envelope-aware counterparts of the plain name-dispatched facade.
+    test:assertTrue(mainModule.includes(
+                    "public isolated function headersFromEdiString(string ediText, EDI_NAME ediName)"),
+            "Default module should dispatch headersFromEdiString by EDI name");
+    test:assertTrue(mainModule.includes(
+                    "public isolated function interchangeFromEdiString(string ediText, EDI_NAME ediName)"),
+            "Default module should dispatch interchangeFromEdiString by EDI name");
+    test:assertTrue(mainModule.includes(
+                    "public isolated function interchangeToEdiString(any msg, EDI_NAME ediName)"),
+            "Default module should dispatch interchangeToEdiString by EDI name");
+    test:assertTrue(mainModule.includes("public isolated function hasEnvelope(EDI_NAME ediName)"),
+            "Default module should expose hasEnvelope so callers can test before dispatching");
+
+    // Only the enveloped schema is registered — SIMPLE has no envelope functions
+    // to point at, so registering it would not compile.
+    test:assertTrue(mainModule.includes("\"ORDERS\": mORDERS:transformInterchangeFromEdiString"),
+            "ORDERS declares an envelope and must be registered");
+    test:assertFalse(mainModule.includes("mSIMPLE:transformInterchangeFromEdiString"),
+            "SIMPLE has no envelope and must not be registered");
+    test:assertFalse(mainModule.includes("mSIMPLE:transformHeadersFromEdiString"),
+            "SIMPLE has no envelope and must not be registered");
+
+    // The transformer of an enveloped module exports the envelope entry points;
+    // the plain one does not.
+    string ordersTransformer = check io:fileReadString(
+            check file:joinPath(libPath, "modules", "mORDERS", "transformer.bal"));
+    test:assertTrue(ordersTransformer.includes("public isolated function transformInterchangeFromEdiString"),
+            "Enveloped module transformer should export transformInterchangeFromEdiString");
+    string simpleTransformer = check io:fileReadString(
+            check file:joinPath(libPath, "modules", "mSIMPLE", "transformer.bal"));
+    test:assertFalse(simpleTransformer.includes("transformInterchangeFromEdiString"),
+            "Plain module transformer must not export envelope functions");
+
+    check file:remove(tmp, file:RECURSIVE);
+}
+
+@test:Config {}
+function testLibgenWithoutEnvelopeOmitsEnvelopeFns() returns error? {
+    string tmp = check file:createTempDir();
+    string schemaPath = check file:joinPath(tmp, "schemas");
+    check file:createDir(schemaPath, file:RECURSIVE);
+    check io:fileWriteJson(check file:joinPath(schemaPath, "SIMPLE.json"), plainSchemaJson);
+    string outputPath = check file:joinPath(tmp, "out");
+    check file:createDir(outputPath, file:RECURSIVE);
+
+    LibData libdata = {
+        orgName: "wso2test",
+        libName: "plainlib",
+        outputPath: outputPath,
+        schemaPath: schemaPath,
+        versioned: false
+    };
+    check generateLibrary(libdata);
+
+    string mainModule = check io:fileReadString(
+            check file:joinPath(outputPath, "plainlib", "plainlib.bal"));
+    test:assertFalse(mainModule.includes("interchangeFromEdiString"),
+            "A library with no enveloped schema should not emit envelope dispatchers");
+    test:assertFalse(mainModule.includes("EdiInterchangeDeserialize"),
+            "A library with no enveloped schema should not emit envelope function types");
+    // The plain facade is untouched.
+    test:assertTrue(mainModule.includes("public isolated function fromEdiString(string ediText, EDI_NAME ediName)"),
+            "The plain facade must still be generated");
+
+    check file:remove(tmp, file:RECURSIVE);
+}
+
+// Compiles the generated library and round-trips an interchange through the
+// default module's name-dispatched envelope functions. This is the only check
+// that exercises `transformInterchangeToEdiString`'s `ensureType` narrowing,
+// which no amount of source inspection can confirm.
+@test:Config {}
+function testLibgenEnvelopeFacadeRoundTrip() returns error? {
+    [string, string] [tmp, libPath] = check generateMixedLibrary("rtlib");
+
+    // The REST connector opens an http:Listener at module init, which would bind
+    // a port for the duration of `bal test`. It is unrelated to the facade under
+    // test, so drop it.
+    check file:remove(check file:joinPath(libPath, "rest_connector.bal"));
+
+    string testDir = check file:joinPath(libPath, "tests");
+    check file:createDir(testDir, file:RECURSIVE);
+    check io:fileWriteString(check file:joinPath(testDir, "facade_test.bal"), string `
+import ballerina/test;
+import rtlib.mORDERS;
+
+final string ediText = "UNB+REF001'UNH+MSG001'BGM+ORDER123'UNT+MSG001'UNZ+REF001'";
+
+@test:Config {}
+function testEnvelopeDispatch() returns error? {
+    test:assertTrue(hasEnvelope(EDI_ORDERS), "ORDERS declares an envelope");
+    test:assertFalse(hasEnvelope(EDI_SIMPLE), "SIMPLE declares no envelope");
+
+    // Headers come back as the submodule's typed record, boxed as anydata.
+    anydata rawHeaders = check headersFromEdiString(ediText, EDI_ORDERS);
+    mORDERS:EDI_ORDERS_OrdersHeaders headers = check rawHeaders.ensureType();
+    test:assertEquals(headers.interchange?.interchange_header?.controlReference, "REF001");
+    test:assertEquals(headers.'transaction?.message_header?.messageReferenceNumber, "MSG001");
+
+    // Full interchange, then write it straight back out through the facade.
+    any rawInterchange = check interchangeFromEdiString(ediText, EDI_ORDERS);
+    mORDERS:EDI_ORDERS_OrdersInterchange interchange = check rawInterchange.ensureType();
+    test:assertEquals(interchange.transactions.length(), 1);
+    test:assertEquals(interchange.interchangeHeader?.interchange_header?.controlReference, "REF001");
+    mORDERS:EDI_ORDERS_Orders body = check interchange.transactions[0].body;
+    test:assertEquals(body.BeginningOfMessage?.documentNumber, "ORDER123");
+
+    // Write the interchange back out and re-read it. Comparing against the input
+    // text would not work — the runtime recomputes the envelope trailer counts
+    // and separates segments with newlines — so the check is structural.
+    string ediOut = check interchangeToEdiString(rawInterchange, EDI_ORDERS);
+    mORDERS:EDI_ORDERS_OrdersInterchange reparsed =
+        check (check interchangeFromEdiString(ediOut, EDI_ORDERS)).ensureType();
+    test:assertEquals(reparsed.interchangeHeader?.interchange_header?.controlReference, "REF001");
+    mORDERS:EDI_ORDERS_Orders reparsedBody = check reparsed.transactions[0].body;
+    test:assertEquals(reparsedBody.BeginningOfMessage?.documentNumber, "ORDER123");
+
+    // A type without an envelope is rejected rather than silently mishandled.
+    any|error noEnvelope = interchangeFromEdiString(ediText, EDI_SIMPLE);
+    test:assertTrue(noEnvelope is error, "SIMPLE must not resolve an envelope deserializer");
+}
+`);
+
+    string balCommand = "bal";
+    string distBin = os:getEnv("BALLERINA_DIST_BIN");
+    if distBin != "" {
+        balCommand = check file:joinPath(distBin, "bal");
+    }
+    os:Process proc = check os:exec({value: balCommand, arguments: ["test", libPath]});
+    int exitCode = check proc.waitForExit();
+
+    // Ballerina has no try/finally and test:assertFail aborts the function, so
+    // the failure message is captured first and the temp dir cleaned up before
+    // the assertion runs.
+    string? failure = ();
+    if exitCode != 0 {
+        string stdoutText = check string:fromBytes(check proc.output(io:stdout));
+        string stderrText = check string:fromBytes(check proc.output(io:stderr));
+        failure = string `Generated library facade test failed (bal test exit ${exitCode}).
+stdout:
+${stdoutText}
+stderr:
+${stderrText}`;
+    }
+
+    check file:remove(tmp, file:RECURSIVE);
+
+    if failure is string {
+        test:assertFail(failure);
+    }
+}

--- a/edi-tools/modules/codegen/transformer_gen.bal
+++ b/edi-tools/modules/codegen/transformer_gen.bal
@@ -14,7 +14,39 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function generateTransformerCode(string ediName, string mainRecordName) returns string {
+function generateTransformerCode(string ediName, string mainRecordName, boolean hasEnvelope) returns string {
+    // Envelope-aware entry points for the name-dispatched facade in the default
+    // module. The interchange ones are typed `any` rather than `anydata` because
+    // `<Name>Transaction.body` is `<Name>|error` (fail-safe parsing) and a value
+    // holding an error is not `anydata`.
+    string envelopeTransformer = !hasEnvelope ? "" : string `
+
+# Convert EDI string to the envelope headers of ${mainRecordName}.
+#
+# + ediText - EDI string to be converted
+# + return - ${mainRecordName}Headers record or error
+public isolated function transformHeadersFromEdiString(string ediText) returns anydata|error {
+    return headersFromEdiString(ediText);
+}
+
+# Convert EDI string to a ${mainRecordName}Interchange record.
+#
+# + ediText - EDI string to be converted
+# + return - ${mainRecordName}Interchange record or error
+public isolated function transformInterchangeFromEdiString(string ediText) returns any|error {
+    return interchangeFromEdiString(ediText);
+}
+
+# Convert a ${mainRecordName}Interchange record to EDI string.
+#
+# + content - ${mainRecordName}Interchange record to be converted
+# + return - EDI string or error
+public isolated function transformInterchangeToEdiString(any content) returns string|error {
+    ${mainRecordName}Interchange msg = check content.ensureType();
+    return interchangeToEdiString(msg);
+}
+`;
+
     string transformer = string `
 type InternalType ${mainRecordName};
 
@@ -39,6 +71,6 @@ public isolated function transformToEdiString(anydata content) returns string|er
 }
 
 isolated function transformWrite(InternalType data) returns ${mainRecordName} => data;
-    `;
+${envelopeTransformer}    `;
     return transformer;
 }

--- a/edi-tools/modules/codegen/transformer_gen.bal
+++ b/edi-tools/modules/codegen/transformer_gen.bal
@@ -22,24 +22,26 @@ function generateTransformerCode(string ediName, string mainRecordName, boolean 
     string envelopeTransformer = !hasEnvelope ? "" : string `
 
 # Convert EDI string to the envelope headers of ${mainRecordName}.
+# Narrow the result with ensureType.
 #
 # + ediText - EDI string to be converted
-# + return - ${mainRecordName}Headers record or error
+# + return - ${mainRecordName}Headers record boxed as anydata, or error
 public isolated function transformHeadersFromEdiString(string ediText) returns anydata|error {
     return headersFromEdiString(ediText);
 }
 
 # Convert EDI string to a ${mainRecordName}Interchange record.
+# Narrow the result with ensureType.
 #
 # + ediText - EDI string to be converted
-# + return - ${mainRecordName}Interchange record or error
+# + return - ${mainRecordName}Interchange record boxed as any, or error
 public isolated function transformInterchangeFromEdiString(string ediText) returns any|error {
     return interchangeFromEdiString(ediText);
 }
 
 # Convert a ${mainRecordName}Interchange record to EDI string.
 #
-# + content - ${mainRecordName}Interchange record to be converted
+# + content - ${mainRecordName}Interchange record boxed as any
 # + return - EDI string or error
 public isolated function transformInterchangeToEdiString(any content) returns string|error {
     ${mainRecordName}Interchange msg = check content.ensureType();


### PR DESCRIPTION
## Purpose

Follow-up to #70. The envelope-aware code generation it introduced lives in `schema_code_gen.bal`, which renders the **per-schema modules** of a `libgen` package. `maincode_gen.bal`, which renders the **default module**, was never updated.

The result: a generated package exposed the envelope API on `mORDERS`, `mINVOIC`, … but not on the package itself.

| | submodule `mORDERS` | default module (before) |
|---|---|---|
| `fromEdiString` / `toEdiString` | ✅ | ✅ |
| `headersFromEdiString` | ✅ | ❌ |
| `interchangeFromEdiString` | ✅ | ❌ |
| `interchangeToEdiString` | ✅ | ❌ |

This affects every enveloped schema, X12 as well as EDIFACT. `bal edi codegen` was unaffected, since it writes a single schema straight into the default module.

## Changes

- **`transformer_gen.bal`** — enveloped modules also emit `transformHeadersFromEdiString`, `transformInterchangeFromEdiString`, `transformInterchangeToEdiString`.
- **`libgen.bal`** — tracks envelope registration *per schema*, so a package mixing enveloped and plain schemas still compiles.
- **`maincode_gen.bal`** — emits `headersFromEdiString(ediText, ediName)`, `interchangeFromEdiString(ediText, ediName)`, `interchangeToEdiString(msg, ediName)`, and `hasEnvelope(ediName)`. A plain type reports an error rather than resolving a dispatcher that does not exist, and the whole block is omitted when no schema in the package has an envelope.

```ballerina
import citymart/porder;
import citymart/porder.m850;

any interchange = check porder:interchangeFromEdiString(orderText, porder:EDI_850);
m850:Purchase_OrderInterchange typed = check interchange.ensureType();
```

### Design notes for review

The interchange dispatchers are typed **`any`**, not `anydata`. `<Name>Transaction.body` is `<Name>|error` for fail-safe parsing, and a value holding an error is not `anydata`, so the existing `EdiDeserialize` shape cannot carry an interchange. Callers narrow with `ensureType`. Headers stay `anydata`, since they genuinely are.

The **REST connector keeps its existing two endpoints**. Its resources return `json`, and an interchange whose bodies are `<Name>|error` has no type-correct `toJson`, so exposing envelopes over HTTP needs an explicit error-projection design — a larger decision than this fix. Happy to take it in a follow-up if wanted.

## Testing

Three tests in `libgen_envelope_test.bal`:

- a mixed enveloped/plain library — the enveloped type is registered, the plain one is not;
- a plain-only library omits the envelope block entirely;
- a **round trip** that generates the library, compiles it with `bal test`, and dispatches parse → serialize → re-parse through the default module. This is the check that exercises the `ensureType` narrowing, which source inspection cannot confirm.

`editools.codegen` is at 10 passing / 0 failing. `testEdifactConversion#0` fails on `main` as well (`Invalid version d03a is given` — the UNECE 403 addressed by #75) and is unrelated.

## Related

Follows #70, #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Expose envelope-aware parsing and serialization functions in generated default modules.
- Add `hasEnvelope(ediName)` for schema-specific envelope detection.
- Support mixed enveloped and plain schemas through per-schema envelope registration.
- Return clear errors when envelope functions are used with plain schemas.
- Omit envelope APIs when no schema uses envelopes.
- Document type handling, `ensureType`, and default-module dispatch.
- Add tests for dispatching, type handling, and round-trip conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->